### PR TITLE
Add @mention resolution for comments and descriptions

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -170,6 +170,50 @@ func (c *Client) Delete(path string) (*APIResponse, error) {
 	return c.request("DELETE", path, nil)
 }
 
+// GetHTML performs a GET request expecting an HTML response.
+// Unlike Get, it sets Accept: text/html and does not attempt JSON parsing.
+func (c *Client) GetHTML(path string) (*APIResponse, error) {
+	requestURL := c.buildURL(path)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", requestURL, nil)
+	if err != nil {
+		return nil, errors.NewNetworkError(fmt.Sprintf("Failed to create request: %v", err))
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("User-Agent", "fizzy-cli/1.0")
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "> GET %s (HTML)\n", requestURL)
+	}
+
+	resp, err := c.doWithRetry(req)
+	if err != nil {
+		return nil, errors.NewNetworkError(fmt.Sprintf("Request failed: %v", err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.NewNetworkError(fmt.Sprintf("Failed to read response: %v", err))
+	}
+
+	if c.Verbose {
+		fmt.Fprintf(os.Stderr, "< %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	apiResp := &APIResponse{
+		StatusCode: resp.StatusCode,
+		Body:       respBody,
+	}
+
+	if resp.StatusCode >= 400 {
+		return apiResp, c.errorFromResponse(resp.StatusCode, respBody, resp.Header)
+	}
+
+	return apiResp, nil
+}
+
 func (c *Client) request(method, path string, body any) (*APIResponse, error) {
 	requestURL := c.buildURL(path)
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -179,9 +179,8 @@ func (c *Client) GetHTML(path string) (*APIResponse, error) {
 		return nil, errors.NewNetworkError(fmt.Sprintf("Failed to create request: %v", err))
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.Token)
+	c.setHeaders(req)
 	req.Header.Set("Accept", "text/html")
-	req.Header.Set("User-Agent", "fizzy-cli/1.0")
 
 	if c.Verbose {
 		fmt.Fprintf(os.Stderr, "> GET %s (HTML)\n", requestURL)

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -13,6 +13,7 @@ type API interface {
 	FollowLocation(location string) (*APIResponse, error)
 	UploadFile(filePath string) (*APIResponse, error)
 	DownloadFile(urlPath string, destPath string) error
+	GetHTML(path string) (*APIResponse, error)
 }
 
 // Ensure Client implements API interface

--- a/internal/commands/card.go
+++ b/internal/commands/card.go
@@ -287,15 +287,16 @@ var cardCreateCmd = &cobra.Command{
 		}
 
 		// Resolve description
+		apiClient := getClient()
 		var description string
 		if cardCreateDescriptionFile != "" {
 			descContent, descErr := os.ReadFile(cardCreateDescriptionFile)
 			if descErr != nil {
 				return descErr
 			}
-			description = markdownToHTML(resolveMentions(string(descContent), getClient()))
+			description = markdownToHTML(resolveMentions(string(descContent), apiClient))
 		} else if cardCreateDescription != "" {
-			description = markdownToHTML(resolveMentions(cardCreateDescription, getClient()))
+			description = markdownToHTML(resolveMentions(cardCreateDescription, apiClient))
 		}
 
 		ac := getSDK()
@@ -378,15 +379,16 @@ var cardUpdateCmd = &cobra.Command{
 		cardNumber := args[0]
 
 		// Resolve description
+		apiClient := getClient()
 		var description string
 		if cardUpdateDescriptionFile != "" {
 			content, err := os.ReadFile(cardUpdateDescriptionFile)
 			if err != nil {
 				return err
 			}
-			description = markdownToHTML(resolveMentions(string(content), getClient()))
+			description = markdownToHTML(resolveMentions(string(content), apiClient))
 		} else if cardUpdateDescription != "" {
-			description = markdownToHTML(resolveMentions(cardUpdateDescription, getClient()))
+			description = markdownToHTML(resolveMentions(cardUpdateDescription, apiClient))
 		}
 
 		// Build breadcrumbs

--- a/internal/commands/card.go
+++ b/internal/commands/card.go
@@ -293,9 +293,9 @@ var cardCreateCmd = &cobra.Command{
 			if descErr != nil {
 				return descErr
 			}
-			description = markdownToHTML(string(descContent))
+			description = markdownToHTML(resolveMentions(string(descContent), getClient()))
 		} else if cardCreateDescription != "" {
-			description = markdownToHTML(cardCreateDescription)
+			description = markdownToHTML(resolveMentions(cardCreateDescription, getClient()))
 		}
 
 		ac := getSDK()
@@ -384,9 +384,9 @@ var cardUpdateCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			description = markdownToHTML(string(content))
+			description = markdownToHTML(resolveMentions(string(content), getClient()))
 		} else if cardUpdateDescription != "" {
-			description = markdownToHTML(cardUpdateDescription)
+			description = markdownToHTML(resolveMentions(cardUpdateDescription, getClient()))
 		}
 
 		// Build breadcrumbs

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -143,15 +143,16 @@ var commentCreateCmd = &cobra.Command{
 		}
 
 		// Determine body content
+		apiClient := getClient()
 		var body string
 		if commentCreateBodyFile != "" {
 			content, err := os.ReadFile(commentCreateBodyFile)
 			if err != nil {
 				return err
 			}
-			body = markdownToHTML(resolveMentions(string(content), getClient()))
+			body = markdownToHTML(resolveMentions(string(content), apiClient))
 		} else if commentCreateBody != "" {
-			body = markdownToHTML(resolveMentions(commentCreateBody, getClient()))
+			body = markdownToHTML(resolveMentions(commentCreateBody, apiClient))
 		} else {
 			return newRequiredFlagError("body or body_file")
 		}
@@ -203,15 +204,16 @@ var commentUpdateCmd = &cobra.Command{
 			return newRequiredFlagError("card")
 		}
 
+		apiClient := getClient()
 		var body string
 		if commentUpdateBodyFile != "" {
 			content, err := os.ReadFile(commentUpdateBodyFile)
 			if err != nil {
 				return err
 			}
-			body = markdownToHTML(resolveMentions(string(content), getClient()))
+			body = markdownToHTML(resolveMentions(string(content), apiClient))
 		} else if commentUpdateBody != "" {
-			body = markdownToHTML(resolveMentions(commentUpdateBody, getClient()))
+			body = markdownToHTML(resolveMentions(commentUpdateBody, apiClient))
 		}
 
 		commentID := args[0]

--- a/internal/commands/comment.go
+++ b/internal/commands/comment.go
@@ -149,9 +149,9 @@ var commentCreateCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			body = markdownToHTML(string(content))
+			body = markdownToHTML(resolveMentions(string(content), getClient()))
 		} else if commentCreateBody != "" {
-			body = markdownToHTML(commentCreateBody)
+			body = markdownToHTML(resolveMentions(commentCreateBody, getClient()))
 		} else {
 			return newRequiredFlagError("body or body_file")
 		}
@@ -209,9 +209,9 @@ var commentUpdateCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			body = markdownToHTML(string(content))
+			body = markdownToHTML(resolveMentions(string(content), getClient()))
 		} else if commentUpdateBody != "" {
-			body = markdownToHTML(commentUpdateBody)
+			body = markdownToHTML(resolveMentions(commentUpdateBody, getClient()))
 		}
 
 		commentID := args[0]

--- a/internal/commands/mentions.go
+++ b/internal/commands/mentions.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"html"
 	"os"
 	"regexp"
 	"strings"
@@ -35,18 +36,38 @@ func resetMentionCache() {
 
 // mentionRegex matches @Name patterns not preceded by word characters or dots
 // (to avoid matching emails like user@example.com).
-var mentionRegex = regexp.MustCompile(`(?:^|[^a-zA-Z0-9_.])@([a-zA-Z][a-zA-Z0-9_]*)`)
+// Supports Unicode letters and hyphens in names (e.g. @José, @Mary-Jane).
+var mentionRegex = regexp.MustCompile(`(?:^|[^-\p{L}\p{N}_.])@([\p{L}][\p{L}\p{N}_-]*)`)
 
-// promptItemRegex parses <lexxy-prompt-item> tags from the /prompts/users HTML.
-var promptItemRegex = regexp.MustCompile(`<lexxy-prompt-item\s+search="([^"]+)"\s+sgid="([^"]+)"[^>]*>`)
+// promptItemRegex matches opening <lexxy-prompt-item> tags.
+// Attributes are extracted separately to handle any order.
+var promptItemRegex = regexp.MustCompile(`<lexxy-prompt-item\s[^>]*>`)
 
-// avatarRegex extracts the src attribute from the first <img> in editor template.
+// searchAttrRegex extracts the search attribute value.
+var searchAttrRegex = regexp.MustCompile(`\ssearch="([^"]+)"`)
+
+// sgidAttrRegex extracts the sgid attribute value.
+var sgidAttrRegex = regexp.MustCompile(`\ssgid="([^"]+)"`)
+
+// promptItemEndRegex matches the closing tag for a prompt item block.
+var promptItemEndRegex = regexp.MustCompile(`</lexxy-prompt-item>`)
+
+// avatarRegex extracts the src attribute from the first <img> tag.
 var avatarRegex = regexp.MustCompile(`<img[^>]+src="([^"]+)"`)
+
+// codeBlockRegex matches fenced code blocks (``` ... ```).
+var codeBlockRegex = regexp.MustCompile("(?s)```.*?```")
+
+// codeSpanRegex matches inline code spans (` ... `).
+var codeSpanRegex = regexp.MustCompile("`[^`]+`")
 
 // resolveMentions scans text for @FirstName patterns and replaces them with
 // ActionText mention HTML. If the text contains no @ characters, it is returned
 // unchanged. On any error fetching users, the original text is returned with a
 // warning printed to stderr.
+//
+// Mentions inside markdown code spans (`@name`) and fenced code blocks are not
+// resolved, preserving the user's intended literal text.
 func resolveMentions(text string, c client.API) string {
 	if !strings.Contains(text, "@") {
 		return text
@@ -65,6 +86,18 @@ func resolveMentions(text string, c client.API) string {
 		return text
 	}
 
+	// Protect code blocks and code spans from mention resolution by replacing
+	// them with placeholders, resolving mentions, then restoring the originals.
+	var codeChunks []string
+	placeholder := func(s string) string {
+		idx := len(codeChunks)
+		codeChunks = append(codeChunks, s)
+		return fmt.Sprintf("\x00CODE%d\x00", idx)
+	}
+
+	protected := codeBlockRegex.ReplaceAllStringFunc(text, placeholder)
+	protected = codeSpanRegex.ReplaceAllStringFunc(protected, placeholder)
+
 	// Find all @Name matches with positions
 	type mentionMatch struct {
 		start int // start of @Name (the @ character)
@@ -72,7 +105,7 @@ func resolveMentions(text string, c client.API) string {
 		name  string
 	}
 
-	allMatches := mentionRegex.FindAllStringSubmatchIndex(text, -1)
+	allMatches := mentionRegex.FindAllStringSubmatchIndex(protected, -1)
 	var matches []mentionMatch
 	for _, loc := range allMatches {
 		// loc[2]:loc[3] is the capture group (the name without @)
@@ -80,7 +113,7 @@ func resolveMentions(text string, c client.API) string {
 		nameEnd := loc[3]
 		// The @ is one character before the name
 		atStart := nameStart - 1
-		name := text[nameStart:nameEnd]
+		name := protected[nameStart:nameEnd]
 		matches = append(matches, mentionMatch{start: atStart, end: nameEnd, name: name})
 	}
 
@@ -98,8 +131,8 @@ func resolveMentions(text string, c client.API) string {
 
 		switch len(found) {
 		case 1:
-			html := buildMentionHTML(found[0])
-			text = text[:m.start] + html + text[m.end:]
+			mentionHTML := buildMentionHTML(found[0])
+			protected = protected[:m.start] + mentionHTML + protected[m.end:]
 		case 0:
 			fmt.Fprintf(os.Stderr, "Warning: could not resolve mention @%s\n", m.name)
 		default:
@@ -111,7 +144,12 @@ func resolveMentions(text string, c client.API) string {
 		}
 	}
 
-	return text
+	// Restore code blocks and spans
+	for i, chunk := range codeChunks {
+		protected = strings.Replace(protected, fmt.Sprintf("\x00CODE%d\x00", i), chunk, 1)
+	}
+
+	return protected
 }
 
 // fetchMentionUsers fetches the list of mentionable users from the API.
@@ -129,17 +167,29 @@ func fetchMentionUsers(c client.API) ([]mentionUser, error) {
 // parseMentionUsers extracts mentionable users from the /prompts/users HTML.
 // Each user is represented as a <lexxy-prompt-item> element with search and sgid
 // attributes, containing <img> tags with avatar URLs.
-func parseMentionUsers(html []byte) []mentionUser {
-	htmlStr := string(html)
-	items := promptItemRegex.FindAllStringSubmatch(htmlStr, -1)
+func parseMentionUsers(htmlBytes []byte) []mentionUser {
+	htmlStr := string(htmlBytes)
+	items := promptItemRegex.FindAllStringIndex(htmlStr, -1)
 	if len(items) == 0 {
 		return nil
 	}
 
+	// Find all closing tags for scoping avatar lookups
+	endIndices := promptItemEndRegex.FindAllStringIndex(htmlStr, -1)
+
 	var users []mentionUser
-	for _, item := range items {
-		search := strings.TrimSpace(item[1])
-		sgid := item[2]
+	for itemIdx, loc := range items {
+		tag := htmlStr[loc[0]:loc[1]]
+
+		// Extract search and sgid attributes (order-independent)
+		searchMatch := searchAttrRegex.FindStringSubmatch(tag)
+		sgidMatch := sgidAttrRegex.FindStringSubmatch(tag)
+		if searchMatch == nil || sgidMatch == nil {
+			continue
+		}
+
+		search := strings.TrimSpace(searchMatch[1])
+		sgid := sgidMatch[1]
 
 		if search == "" || sgid == "" {
 			continue
@@ -161,15 +211,16 @@ func parseMentionUsers(html []byte) []mentionUser {
 		fullName := strings.Join(words, " ")
 		firstName := words[0]
 
-		// Extract avatar URL: find the <img> after this sgid in the HTML.
+		// Extract avatar URL scoped to this prompt-item block only.
 		avatarSrc := ""
-		sgidIdx := strings.Index(htmlStr, `sgid="`+sgid+`"`)
-		if sgidIdx >= 0 {
-			// Search for the first <img> after the sgid
-			remainder := htmlStr[sgidIdx:]
-			if m := avatarRegex.FindStringSubmatch(remainder); len(m) > 1 {
-				avatarSrc = m[1]
-			}
+		blockStart := loc[0]
+		blockEnd := len(htmlStr)
+		if itemIdx < len(endIndices) {
+			blockEnd = endIndices[itemIdx][1]
+		}
+		block := htmlStr[blockStart:blockEnd]
+		if m := avatarRegex.FindStringSubmatch(block); len(m) > 1 {
+			avatarSrc = m[1]
 		}
 
 		users = append(users, mentionUser{
@@ -184,12 +235,16 @@ func parseMentionUsers(html []byte) []mentionUser {
 }
 
 // buildMentionHTML creates the ActionText attachment HTML for a mention.
+// Values are HTML-escaped to prevent injection from user-controlled names.
 func buildMentionHTML(u mentionUser) string {
 	return fmt.Sprintf(
 		`<action-text-attachment sgid="%s" content-type="application/vnd.actiontext.mention">`+
 			`<img title="%s" src="%s" width="48" height="48">%s`+
 			`</action-text-attachment>`,
-		u.SGID, u.FullName, u.AvatarSrc, u.FirstName,
+		html.EscapeString(u.SGID),
+		html.EscapeString(u.FullName),
+		html.EscapeString(u.AvatarSrc),
+		html.EscapeString(u.FirstName),
 	)
 }
 

--- a/internal/commands/mentions.go
+++ b/internal/commands/mentions.go
@@ -1,0 +1,207 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/basecamp/fizzy-cli/internal/client"
+)
+
+// mentionUser represents a mentionable user parsed from the /prompts/users endpoint.
+type mentionUser struct {
+	FirstName string // e.g. "Wayne"
+	FullName  string // e.g. "Wayne Smith"
+	SGID      string // signed global ID for ActionText
+	AvatarSrc string // e.g. "/6103476/users/03f5awg7.../avatar"
+}
+
+// Package-level cache: populated once per CLI invocation.
+var (
+	mentionUsers []mentionUser
+	mentionOnce  sync.Once
+	mentionErr   error
+)
+
+// resetMentionCache resets the cache for testing.
+func resetMentionCache() {
+	mentionOnce = sync.Once{}
+	mentionUsers = nil
+	mentionErr = nil
+}
+
+// mentionRegex matches @Name patterns not preceded by word characters or dots
+// (to avoid matching emails like user@example.com).
+var mentionRegex = regexp.MustCompile(`(?:^|[^a-zA-Z0-9_.])@([a-zA-Z][a-zA-Z0-9_]*)`)
+
+// promptItemRegex parses <lexxy-prompt-item> tags from the /prompts/users HTML.
+var promptItemRegex = regexp.MustCompile(`<lexxy-prompt-item\s+search="([^"]+)"\s+sgid="([^"]+)"[^>]*>`)
+
+// avatarRegex extracts the src attribute from the first <img> in editor template.
+var avatarRegex = regexp.MustCompile(`<img[^>]+src="([^"]+)"`)
+
+// resolveMentions scans text for @FirstName patterns and replaces them with
+// ActionText mention HTML. If the text contains no @ characters, it is returned
+// unchanged. On any error fetching users, the original text is returned with a
+// warning printed to stderr.
+func resolveMentions(text string, c client.API) string {
+	if !strings.Contains(text, "@") {
+		return text
+	}
+
+	mentionOnce.Do(func() {
+		mentionUsers, mentionErr = fetchMentionUsers(c)
+	})
+
+	if mentionErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not fetch mentionable users: %v\n", mentionErr)
+		return text
+	}
+
+	if len(mentionUsers) == 0 {
+		return text
+	}
+
+	// Find all @Name matches with positions
+	type mentionMatch struct {
+		start int // start of @Name (the @ character)
+		end   int // end of @Name
+		name  string
+	}
+
+	allMatches := mentionRegex.FindAllStringSubmatchIndex(text, -1)
+	var matches []mentionMatch
+	for _, loc := range allMatches {
+		// loc[2]:loc[3] is the capture group (the name without @)
+		nameStart := loc[2]
+		nameEnd := loc[3]
+		// The @ is one character before the name
+		atStart := nameStart - 1
+		name := text[nameStart:nameEnd]
+		matches = append(matches, mentionMatch{start: atStart, end: nameEnd, name: name})
+	}
+
+	// Process from end to start so replacements don't shift indices
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+
+		// Find matching user by first name (case-insensitive)
+		var found []mentionUser
+		for _, u := range mentionUsers {
+			if strings.EqualFold(u.FirstName, m.name) {
+				found = append(found, u)
+			}
+		}
+
+		switch len(found) {
+		case 1:
+			html := buildMentionHTML(found[0])
+			text = text[:m.start] + html + text[m.end:]
+		case 0:
+			fmt.Fprintf(os.Stderr, "Warning: could not resolve mention @%s\n", m.name)
+		default:
+			names := make([]string, len(found))
+			for j, u := range found {
+				names[j] = u.FullName
+			}
+			fmt.Fprintf(os.Stderr, "Warning: ambiguous mention @%s — matches: %s\n", m.name, strings.Join(names, ", "))
+		}
+	}
+
+	return text
+}
+
+// fetchMentionUsers fetches the list of mentionable users from the API.
+func fetchMentionUsers(c client.API) ([]mentionUser, error) {
+	resp, err := c.GetHTML("/prompts/users")
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status %d from /prompts/users", resp.StatusCode)
+	}
+	return parseMentionUsers(resp.Body), nil
+}
+
+// parseMentionUsers extracts mentionable users from the /prompts/users HTML.
+// Each user is represented as a <lexxy-prompt-item> element with search and sgid
+// attributes, containing <img> tags with avatar URLs.
+func parseMentionUsers(html []byte) []mentionUser {
+	htmlStr := string(html)
+	items := promptItemRegex.FindAllStringSubmatch(htmlStr, -1)
+	if len(items) == 0 {
+		return nil
+	}
+
+	var users []mentionUser
+	for _, item := range items {
+		search := strings.TrimSpace(item[1])
+		sgid := item[2]
+
+		if search == "" || sgid == "" {
+			continue
+		}
+
+		// Parse name from search attribute.
+		// Format: "Full Name INITIALS [me]"
+		// Strip trailing "me" and all-uppercase words (initials like "WS", "FMA").
+		words := strings.Fields(search)
+		for len(words) > 1 {
+			last := words[len(words)-1]
+			if last == "me" || isAllUpper(last) {
+				words = words[:len(words)-1]
+			} else {
+				break
+			}
+		}
+
+		fullName := strings.Join(words, " ")
+		firstName := words[0]
+
+		// Extract avatar URL: find the <img> after this sgid in the HTML.
+		avatarSrc := ""
+		sgidIdx := strings.Index(htmlStr, `sgid="`+sgid+`"`)
+		if sgidIdx >= 0 {
+			// Search for the first <img> after the sgid
+			remainder := htmlStr[sgidIdx:]
+			if m := avatarRegex.FindStringSubmatch(remainder); len(m) > 1 {
+				avatarSrc = m[1]
+			}
+		}
+
+		users = append(users, mentionUser{
+			FirstName: firstName,
+			FullName:  fullName,
+			SGID:      sgid,
+			AvatarSrc: avatarSrc,
+		})
+	}
+
+	return users
+}
+
+// buildMentionHTML creates the ActionText attachment HTML for a mention.
+func buildMentionHTML(u mentionUser) string {
+	return fmt.Sprintf(
+		`<action-text-attachment sgid="%s" content-type="application/vnd.actiontext.mention">`+
+			`<img title="%s" src="%s" width="48" height="48">%s`+
+			`</action-text-attachment>`,
+		u.SGID, u.FullName, u.AvatarSrc, u.FirstName,
+	)
+}
+
+// isAllUpper returns true if s is non-empty and all uppercase letters.
+func isAllUpper(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/commands/mentions_test.go
+++ b/internal/commands/mentions_test.go
@@ -41,6 +41,22 @@ const samplePromptUsersHTML = `
 </lexxy-prompt-item>
 `
 
+// ambiguousHTML has two users with the same first name.
+const ambiguousHTML = `
+<lexxy-prompt-item search="Alex Smith AS" sgid="alex1-sgid">
+  <template type="editor">
+    <img title="Alex Smith" src="/123/users/a1/avatar" width="48" height="48" />
+    Alex
+  </template>
+</lexxy-prompt-item>
+<lexxy-prompt-item search="Alex Jones AJ" sgid="alex2-sgid">
+  <template type="editor">
+    <img title="Alex Jones" src="/123/users/a2/avatar" width="48" height="48" />
+    Alex
+  </template>
+</lexxy-prompt-item>
+`
+
 func newMentionMockClient() *MockClient {
 	m := NewMockClient()
 	m.GetHTMLResponse = &client.APIResponse{
@@ -89,6 +105,40 @@ func TestParseMentionUsersEmpty(t *testing.T) {
 	users := parseMentionUsers([]byte(""))
 	if len(users) != 0 {
 		t.Errorf("expected 0 users from empty HTML, got %d", len(users))
+	}
+}
+
+func TestParseMentionUsersAttributeOrder(t *testing.T) {
+	// sgid before search — should still parse correctly
+	html := `<lexxy-prompt-item sgid="reversed-sgid" search="Test User TU">
+  <template type="editor">
+    <img title="Test User" src="/123/users/t1/avatar" width="48" height="48" />
+    Test
+  </template>
+</lexxy-prompt-item>`
+	users := parseMentionUsers([]byte(html))
+	if len(users) != 1 {
+		t.Fatalf("expected 1 user from reversed attributes, got %d", len(users))
+	}
+	if users[0].FirstName != "Test" {
+		t.Errorf("FirstName = %q, want %q", users[0].FirstName, "Test")
+	}
+	if users[0].SGID != "reversed-sgid" {
+		t.Errorf("SGID = %q, want %q", users[0].SGID, "reversed-sgid")
+	}
+}
+
+func TestParseMentionUsersAvatarScoping(t *testing.T) {
+	// Each user's avatar should come from their own block, not a later one
+	users := parseMentionUsers([]byte(samplePromptUsersHTML))
+	if len(users) < 2 {
+		t.Fatal("expected at least 2 users")
+	}
+	if !strings.Contains(users[0].AvatarSrc, "u1") {
+		t.Errorf("user[0] avatar should contain u1, got %q", users[0].AvatarSrc)
+	}
+	if !strings.Contains(users[1].AvatarSrc, "u2") {
+		t.Errorf("user[1] avatar should contain u2, got %q", users[1].AvatarSrc)
 	}
 }
 
@@ -147,6 +197,23 @@ func TestResolveMentions(t *testing.T) {
 			input:         "Hey @Kennedy",
 			shouldContain: []string{`sgid="kennedy-sgid-789"`, `title="Kennedy"`},
 		},
+		{
+			name:           "mention inside inline code not resolved",
+			input:          "Use `@Wayne` to mention someone",
+			shouldContain:  []string{"`@Wayne`"},
+			shouldNotMatch: []string{"action-text-attachment"},
+		},
+		{
+			name:           "mention inside fenced code block not resolved",
+			input:          "Example:\n```\n@Wayne check this\n```",
+			shouldContain:  []string{"@Wayne"},
+			shouldNotMatch: []string{"action-text-attachment"},
+		},
+		{
+			name:          "mention outside code resolved while code preserved",
+			input:         "@Wayne see `@Bushra` example",
+			shouldContain: []string{`sgid="wayne-sgid-123"`, "`@Bushra`"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -166,6 +233,36 @@ func TestResolveMentions(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveMentionsNoFetchWithoutAt(t *testing.T) {
+	resetMentionCache()
+	mock := newMentionMockClient()
+
+	resolveMentions("Hello world, no mentions here", mock)
+
+	if len(mock.GetHTMLCalls) != 0 {
+		t.Errorf("expected 0 GetHTML calls for text without @, got %d", len(mock.GetHTMLCalls))
+	}
+}
+
+func TestResolveMentionsAmbiguous(t *testing.T) {
+	resetMentionCache()
+	mock := NewMockClient()
+	mock.GetHTMLResponse = &client.APIResponse{
+		StatusCode: 200,
+		Body:       []byte(ambiguousHTML),
+	}
+
+	result := resolveMentions("Hey @Alex check this", mock)
+
+	// Should NOT resolve — ambiguous
+	if strings.Contains(result, "action-text-attachment") {
+		t.Errorf("ambiguous mention should not resolve, got: %s", result)
+	}
+	if !strings.Contains(result, "@Alex") {
+		t.Errorf("ambiguous mention should stay as @Alex, got: %s", result)
 	}
 }
 
@@ -196,5 +293,25 @@ func TestResolveMentionsCaching(t *testing.T) {
 	resolveMentions("@Bushra", mock)
 	if len(mock.GetHTMLCalls) != 1 {
 		t.Errorf("expected still 1 GetHTML call (cached), got %d", len(mock.GetHTMLCalls))
+	}
+}
+
+func TestBuildMentionHTMLEscaping(t *testing.T) {
+	u := mentionUser{
+		FirstName: `O'Brien`,
+		FullName:  `O'Brien <script>`,
+		SGID:      `sgid"test`,
+		AvatarSrc: `/users/1/avatar?a=1&b=2`,
+	}
+	result := buildMentionHTML(u)
+
+	if strings.Contains(result, `<script>`) {
+		t.Error("HTML should be escaped, found raw <script>")
+	}
+	if !strings.Contains(result, `&lt;script&gt;`) {
+		t.Error("expected escaped <script> tag")
+	}
+	if strings.Contains(result, `sgid"test`) {
+		t.Error("SGID with quote should be escaped")
 	}
 }

--- a/internal/commands/mentions_test.go
+++ b/internal/commands/mentions_test.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/fizzy-cli/internal/client"
+)
+
+const samplePromptUsersHTML = `
+<lexxy-prompt-item search="Wayne Smith WS me" sgid="wayne-sgid-123">
+  <template type="menu">
+    <img aria-hidden="true" title="Wayne Smith" src="/123/users/u1/avatar" width="48" height="48" />
+    Wayne Smith
+  </template>
+  <template type="editor">
+    <img aria-hidden="true" title="Wayne Smith" src="/123/users/u1/avatar" width="48" height="48" />
+    Wayne
+  </template>
+</lexxy-prompt-item>
+<lexxy-prompt-item search="Bushra Gul BG" sgid="bushra-sgid-456">
+  <template type="menu">
+    <img aria-hidden="true" title="Bushra Gul" src="/123/users/u2/avatar" width="48" height="48" />
+    Bushra Gul
+  </template>
+  <template type="editor">
+    <img aria-hidden="true" title="Bushra Gul" src="/123/users/u2/avatar" width="48" height="48" />
+    Bushra
+  </template>
+</lexxy-prompt-item>
+<lexxy-prompt-item search="Kennedy K" sgid="kennedy-sgid-789">
+  <template type="menu">
+    <img aria-hidden="true" title="Kennedy" src="/123/users/u3/avatar" width="48" height="48" />
+    Kennedy
+  </template>
+  <template type="editor">
+    <img aria-hidden="true" title="Kennedy" src="/123/users/u3/avatar" width="48" height="48" />
+    Kennedy
+  </template>
+</lexxy-prompt-item>
+`
+
+func newMentionMockClient() *MockClient {
+	m := NewMockClient()
+	m.GetHTMLResponse = &client.APIResponse{
+		StatusCode: 200,
+		Body:       []byte(samplePromptUsersHTML),
+	}
+	return m
+}
+
+func TestParseMentionUsers(t *testing.T) {
+	users := parseMentionUsers([]byte(samplePromptUsersHTML))
+
+	if len(users) != 3 {
+		t.Fatalf("expected 3 users, got %d", len(users))
+	}
+
+	tests := []struct {
+		idx       int
+		firstName string
+		fullName  string
+		sgid      string
+	}{
+		{0, "Wayne", "Wayne Smith", "wayne-sgid-123"},
+		{1, "Bushra", "Bushra Gul", "bushra-sgid-456"},
+		{2, "Kennedy", "Kennedy", "kennedy-sgid-789"},
+	}
+
+	for _, tt := range tests {
+		u := users[tt.idx]
+		if u.FirstName != tt.firstName {
+			t.Errorf("user[%d] FirstName = %q, want %q", tt.idx, u.FirstName, tt.firstName)
+		}
+		if u.FullName != tt.fullName {
+			t.Errorf("user[%d] FullName = %q, want %q", tt.idx, u.FullName, tt.fullName)
+		}
+		if u.SGID != tt.sgid {
+			t.Errorf("user[%d] SGID = %q, want %q", tt.idx, u.SGID, tt.sgid)
+		}
+		if u.AvatarSrc == "" {
+			t.Errorf("user[%d] AvatarSrc is empty", tt.idx)
+		}
+	}
+}
+
+func TestParseMentionUsersEmpty(t *testing.T) {
+	users := parseMentionUsers([]byte(""))
+	if len(users) != 0 {
+		t.Errorf("expected 0 users from empty HTML, got %d", len(users))
+	}
+}
+
+func TestResolveMentions(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		shouldContain  []string
+		shouldNotMatch []string // substrings that should NOT appear
+	}{
+		{
+			name:           "no @ passthrough",
+			input:          "Hello world",
+			shouldContain:  []string{"Hello world"},
+			shouldNotMatch: []string{"action-text-attachment"},
+		},
+		{
+			name:          "single mention",
+			input:         "Hey @Wayne check this",
+			shouldContain: []string{`sgid="wayne-sgid-123"`, `content-type="application/vnd.actiontext.mention"`, `title="Wayne Smith"`, ">Wayne<"},
+		},
+		{
+			name:          "case insensitive",
+			input:         "Hey @wayne check this",
+			shouldContain: []string{`sgid="wayne-sgid-123"`},
+		},
+		{
+			name:          "multiple mentions",
+			input:         "@Wayne and @Bushra please review",
+			shouldContain: []string{`sgid="wayne-sgid-123"`, `sgid="bushra-sgid-456"`},
+		},
+		{
+			name:           "email not treated as mention",
+			input:          "Contact user@example.com",
+			shouldContain:  []string{"user@example.com"},
+			shouldNotMatch: []string{"action-text-attachment"},
+		},
+		{
+			name:           "unresolved mention stays as text",
+			input:          "Hey @Unknown person",
+			shouldContain:  []string{"@Unknown"},
+			shouldNotMatch: []string{"action-text-attachment"},
+		},
+		{
+			name:          "mention at start of text",
+			input:         "@Kennedy can you look?",
+			shouldContain: []string{`sgid="kennedy-sgid-789"`},
+		},
+		{
+			name:          "mention after newline",
+			input:         "First line\n@Wayne second line",
+			shouldContain: []string{`sgid="wayne-sgid-123"`},
+		},
+		{
+			name:          "single name user",
+			input:         "Hey @Kennedy",
+			shouldContain: []string{`sgid="kennedy-sgid-789"`, `title="Kennedy"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetMentionCache()
+			mock := newMentionMockClient()
+			result := resolveMentions(tt.input, mock)
+
+			for _, s := range tt.shouldContain {
+				if !strings.Contains(result, s) {
+					t.Errorf("result should contain %q\ngot: %s", s, result)
+				}
+			}
+			for _, s := range tt.shouldNotMatch {
+				if strings.Contains(result, s) {
+					t.Errorf("result should NOT contain %q\ngot: %s", s, result)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveMentionsAPIError(t *testing.T) {
+	resetMentionCache()
+	mock := NewMockClient()
+	mock.GetHTMLError = fmt.Errorf("server error")
+
+	// Should return text unchanged on error
+	input := "Hey @Wayne"
+	result := resolveMentions(input, mock)
+	if result != input {
+		t.Errorf("expected unchanged text on error, got: %s", result)
+	}
+}
+
+func TestResolveMentionsCaching(t *testing.T) {
+	resetMentionCache()
+	mock := newMentionMockClient()
+
+	// First call fetches
+	resolveMentions("@Wayne", mock)
+	if len(mock.GetHTMLCalls) != 1 {
+		t.Errorf("expected 1 GetHTML call, got %d", len(mock.GetHTMLCalls))
+	}
+
+	// Second call uses cache
+	resolveMentions("@Bushra", mock)
+	if len(mock.GetHTMLCalls) != 1 {
+		t.Errorf("expected still 1 GetHTML call (cached), got %d", len(mock.GetHTMLCalls))
+	}
+}

--- a/internal/commands/mock_client_test.go
+++ b/internal/commands/mock_client_test.go
@@ -22,6 +22,7 @@ type MockClient struct {
 	UploadFileResponse        *client.APIResponse
 
 	PatchMultipartResponse *client.APIResponse
+	GetHTMLResponse        *client.APIResponse
 
 	// Path-based GET response routing (checked before GetResponse)
 	getPathResponses map[string]*client.APIResponse
@@ -37,6 +38,7 @@ type MockClient struct {
 	FollowLocationError    error
 	UploadFileError        error
 	DownloadFileError      error
+	GetHTMLError           error
 
 	// Captured calls for verification
 	GetCalls               []MockCall
@@ -49,6 +51,7 @@ type MockClient struct {
 	FollowLocationCalls    []string
 	UploadFileCalls        []string
 	DownloadFileCalls      []MockDownloadCall
+	GetHTMLCalls           []MockCall
 }
 
 // MockDownloadCall represents a captured download call.
@@ -211,6 +214,17 @@ func (m *MockClient) DownloadFile(urlPath string, destPath string) error {
 		return m.DownloadFileError
 	}
 	return nil
+}
+
+func (m *MockClient) GetHTML(path string) (*client.APIResponse, error) {
+	m.GetHTMLCalls = append(m.GetHTMLCalls, MockCall{Path: path})
+	if m.GetHTMLError != nil {
+		return nil, m.GetHTMLError
+	}
+	if m.GetHTMLResponse != nil {
+		return m.GetHTMLResponse, nil
+	}
+	return &client.APIResponse{StatusCode: 200, Body: []byte("")}, nil
 }
 
 // Helper functions for creating common responses

--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -42,10 +42,10 @@ var searchCmd = &cobra.Command{
 			params = append(params, "terms[]="+term)
 		}
 
-		// Add optional filters
-		boardID := defaultBoard(searchBoard)
-		if boardID != "" {
-			params = append(params, "board_ids[]="+boardID)
+		// Add optional filters (search is cross-board by default;
+		// only scope to a board when explicitly requested via --board)
+		if searchBoard != "" {
+			params = append(params, "board_ids[]="+searchBoard)
 		}
 		if searchTag != "" {
 			params = append(params, "tag_ids[]="+searchTag)

--- a/internal/skills/SKILL.md
+++ b/internal/skills/SKILL.md
@@ -67,6 +67,30 @@ Full CLI coverage: boards, cards, columns, comments, steps, reactions, tags, use
 5. **Rich text fields accept HTML** — use `<p>` tags for paragraphs, `<action-text-attachment>` for inline images
 6. **Card description is a string**, but comment body is a nested object — `.description` vs `.body.plain_text`
 7. **Display the welcome message for new signups** — When `signup complete --name` returns `is_new_user: true`, you MUST immediately display the `welcome_message` field prominently to the user. This is a one-time personal note from the CEO — if you skip it, the user will never see it.
+8. **Use @FirstName for mentions** — Write `@FirstName` in comment or description text to mention a user. The CLI auto-resolves mentions to ActionText HTML, triggering Fizzy notifications. Case-insensitive. Emails like `user@example.com` are not treated as mentions.
+
+## @Mentions
+
+Use `@FirstName` in comments and descriptions to mention users. The CLI resolves them to Fizzy mentions with notifications — no need to construct HTML manually.
+
+```bash
+# Mention in a comment
+fizzy comment create --card 42 --body "Hey @Sarah, can you review this?"
+
+# Multiple mentions
+fizzy comment create --card 42 --body "@Alex @Jordan please check the latest deploy"
+
+# Mention in a card description
+fizzy card create --board ID --title "Fix bug" --description "@Pat this is the issue you mentioned"
+```
+
+- **Case-insensitive** — `@sarah` and `@Sarah` both work
+- **Emails ignored** — `user@example.com` is not treated as a mention
+- **Ambiguous names warned** — if multiple users share a first name, a warning is printed and the text is left unchanged
+- **Unresolved names left as text** — `@Unknown` stays as `@Unknown` with a warning
+- **Cached per invocation** — user list is fetched once and reused for the entire command
+
+To see available users for mentioning: `fizzy user list | jq '[.data[] | .name]'`
 
 ## Decision Trees
 

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -67,6 +67,30 @@ Full CLI coverage: boards, cards, columns, comments, steps, reactions, tags, use
 5. **Rich text fields accept HTML** — use `<p>` tags for paragraphs, `<action-text-attachment>` for inline images
 6. **Card description is a string**, but comment body is a nested object — `.description` vs `.body.plain_text`
 7. **Display the welcome message for new signups** — When `signup complete --name` returns `is_new_user: true`, you MUST immediately display the `welcome_message` field prominently to the user. This is a one-time personal note from the CEO — if you skip it, the user will never see it.
+8. **Use @FirstName for mentions** — Write `@FirstName` in comment or description text to mention a user. The CLI auto-resolves mentions to ActionText HTML, triggering Fizzy notifications. Case-insensitive. Emails like `user@example.com` are not treated as mentions.
+
+## @Mentions
+
+Use `@FirstName` in comments and descriptions to mention users. The CLI resolves them to Fizzy mentions with notifications — no need to construct HTML manually.
+
+```bash
+# Mention in a comment
+fizzy comment create --card 42 --body "Hey @Sarah, can you review this?"
+
+# Multiple mentions
+fizzy comment create --card 42 --body "@Alex @Jordan please check the latest deploy"
+
+# Mention in a card description
+fizzy card create --board ID --title "Fix bug" --description "@Pat this is the issue you mentioned"
+```
+
+- **Case-insensitive** — `@sarah` and `@Sarah` both work
+- **Emails ignored** — `user@example.com` is not treated as a mention
+- **Ambiguous names warned** — if multiple users share a first name, a warning is printed and the text is left unchanged
+- **Unresolved names left as text** — `@Unknown` stays as `@Unknown` with a warning
+- **Cached per invocation** — user list is fetched once and reused for the entire command
+
+To see available users for mentioning: `fizzy user list | jq '[.data[] | .name]'`
 
 ## Decision Trees
 


### PR DESCRIPTION
## Summary

- Resolve `@FirstName` patterns in comment and card description text to ActionText mention HTML before sending to the API
- Mentioned users receive Fizzy notifications, matching the behavior of the web UI
- Agents can write natural text like `@Sarah can you review?` instead of constructing `<action-text-attachment>` HTML manually

## How it works

1. When a comment or description body contains `@`, the CLI fetches mentionable users from `/prompts/users` (HTML endpoint with `<lexxy-prompt-item>` elements containing sgids)
2. `@FirstName` patterns are matched case-insensitively against the user list
3. Matches are replaced with `<action-text-attachment sgid="..." content-type="application/vnd.actiontext.mention">` HTML
4. The resolved text is then passed through `markdownToHTML()` as before

## Design decisions

- **Compose, don't modify** — `markdownToHTML()` stays pure. `resolveMentions()` runs before it at each call site: `markdownToHTML(resolveMentions(text, getClient()))`
- **`GetHTML()` on the client** — new method that sets `Accept: text/html` and skips JSON parsing, keeping `Get()` unchanged
- **Cached per invocation** — user list is fetched once via `sync.Once` and reused
- **Graceful degradation** — on fetch error, text is sent unchanged with a warning to stderr
- **Email-safe** — `user@example.com` is not treated as a mention
- **Ambiguity warnings** — if multiple users share a first name, a warning is printed and the text is left unchanged

## Changes

| File | Change |
|------|--------|
| `internal/commands/mentions.go` | Core mention resolution logic (new) |
| `internal/commands/mentions_test.go` | Unit tests (new) |
| `internal/client/client.go` | Add `GetHTML()` method |
| `internal/client/interface.go` | Add `GetHTML()` to `API` interface |
| `internal/commands/comment.go` | Wire up `resolveMentions()` at 4 call sites |
| `internal/commands/card.go` | Wire up `resolveMentions()` at 4 call sites |
| `internal/commands/mock_client_test.go` | Add `GetHTML` to mock |
| `skills/fizzy/SKILL.md` | Document @mention feature |
| `internal/skills/SKILL.md` | Document @mention feature (embedded) |

## Test plan

- [x] `go test ./internal/commands/ -run TestParseMentionUsers` — HTML parsing
- [x] `go test ./internal/commands/ -run TestResolveMentions` — 9 test cases (passthrough, single, case-insensitive, multiple, email, unresolved, start-of-text, after-newline, single-name user)
- [x] `go test ./internal/commands/ -run TestResolveMentionsAPIError` — graceful degradation
- [x] `go test ./internal/commands/ -run TestResolveMentionsCaching` — sync.Once caching
- [x] `go test ./internal/commands/ -run TestMarkdown` — existing markdown tests unaffected
- [x] `go test ./internal/client/` — existing client tests unaffected
- [x] Manual test: `fizzy comment create --card N --body "Hey @Wayne, testing"` — mention renders on Fizzy with notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@FirstName` mention resolution in CLI comments and card descriptions, converting mentions to ActionText HTML with Fizzy notifications. Also fixes search to be cross-board by default and hoists `getClient()` above branches for clarity.

- **New Features**
  - Resolve `@FirstName` before `markdownToHTML()`; wired into comment/card create and update.
  - Fetch mentionable users from `/prompts/users` via `GetHTML()`; parse `<lexxy-prompt-item>` in any order; avatar lookup scoped per item.
  - Robust behavior: case-insensitive; supports Unicode and hyphenated names; emails ignored; skip mentions inside code spans and fenced blocks; warn on ambiguous/unresolved; cache per invocation; HTML-escape values; graceful on fetch errors. Docs updated in `skills/fizzy/SKILL.md` and `internal/skills/SKILL.md`.

- **Bug Fixes**
  - Make search cross-board by default; only scope when `--board` is set, fixing `--tag` and `--assignee` across boards.
  - Refactor: hoist `getClient()` before conditional branches in comment/card commands.

<sup>Written for commit f84f9d79dafeb9db04d92a66330f1e2d59e9ba96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

