### PR TITLE
Fix search to be cross-board by default

### DIFF
--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -42,10 +42,10 @@ var searchCmd = &cobra.Command{
 			params = append(params, "terms[]="+term)
 		}
 
-		// Add optional filters
-		boardID := defaultBoard(searchBoard)
-		if boardID != "" {
-			params = append(params, "board_ids[]="+boardID)
+		// Add optional filters (search is cross-board by default;
+		// only scope to a board when explicitly requested via --board)
+		if searchBoard != "" {
+			params = append(params, "board_ids[]="+searchBoard)
 		}
 		if searchTag != "" {
 			params = append(params, "tag_ids[]="+searchTag)

--- a/internal/commands/search_test.go
+++ b/internal/commands/search_test.go
@@ -148,6 +148,58 @@ func TestSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("tag filter works cross-board with default board set", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []any{},
+		}
+
+		SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		cfg.Board = "default-board-id"
+		defer resetTest()
+
+		searchTag = "tag-123"
+		err := searchCmd.RunE(searchCmd, []string{"bug"})
+		searchTag = ""
+
+		assertExitCode(t, err, 0)
+		if len(mock.GetWithPaginationCalls) != 1 {
+			t.Fatalf("expected 1 GetWithPagination call, got %d", len(mock.GetWithPaginationCalls))
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug&tag_ids[]=tag-123" {
+			t.Errorf("expected tag filter without board_ids, got '%s'", path)
+		}
+	})
+
+	t.Run("assignee filter works cross-board with default board set", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []any{},
+		}
+
+		SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		cfg.Board = "default-board-id"
+		defer resetTest()
+
+		searchAssignee = "user-456"
+		err := searchCmd.RunE(searchCmd, []string{"bug"})
+		searchAssignee = ""
+
+		assertExitCode(t, err, 0)
+		if len(mock.GetWithPaginationCalls) != 1 {
+			t.Fatalf("expected 1 GetWithPagination call, got %d", len(mock.GetWithPaginationCalls))
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug&assignee_ids[]=user-456" {
+			t.Errorf("expected assignee filter without board_ids, got '%s'", path)
+		}
+	})
+
 	t.Run("requires authentication", func(t *testing.T) {
 		mock := NewMockClient()
 		SetTestModeWithSDK(mock)

--- a/internal/commands/search_test.go
+++ b/internal/commands/search_test.go
@@ -122,6 +122,29 @@ func TestSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("does not inject default board into search", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []any{},
+		}
+
+		SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		cfg.Board = "default-board-id"
+		defer resetTest()
+
+		searchBoard = ""
+		err := searchCmd.RunE(searchCmd, []string{"bug"})
+		searchBoard = ""
+
+		assertExitCode(t, err, 0)
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug" {
+			t.Errorf("expected no board_ids in path, got '%s'", path)
+		}
+	})
+
 	t.Run("requires authentication", func(t *testing.T) {
 		mock := NewMockClient()
 		SetTestModeWithSDK(mock)

--- a/internal/commands/search_test.go
+++ b/internal/commands/search_test.go
@@ -139,6 +139,9 @@ func TestSearch(t *testing.T) {
 		searchBoard = ""
 
 		assertExitCode(t, err, 0)
+		if len(mock.GetWithPaginationCalls) != 1 {
+			t.Fatalf("expected 1 GetWithPagination call, got %d", len(mock.GetWithPaginationCalls))
+		}
 		path := mock.GetWithPaginationCalls[0].Path
 		if path != "/cards.json?terms[]=bug" {
 			t.Errorf("expected no board_ids in path, got '%s'", path)

--- a/internal/commands/search_test.go
+++ b/internal/commands/search_test.go
@@ -134,9 +134,7 @@ func TestSearch(t *testing.T) {
 		cfg.Board = "default-board-id"
 		defer resetTest()
 
-		searchBoard = ""
 		err := searchCmd.RunE(searchCmd, []string{"bug"})
-		searchBoard = ""
 
 		assertExitCode(t, err, 0)
 		if len(mock.GetWithPaginationCalls) != 1 {


### PR DESCRIPTION
## Summary

- `search` called `defaultBoard()` which injected the configured default board into every query, silently scoping results to a single board
- This made `--tag` and `--assignee` filters appear broken when matching cards existed on other boards
- Fix: only add `board_ids[]` when `--board` is explicitly passed

Closes #113

## Test plan

- [x] `go test ./internal/commands/ -run TestSearch` — all 6 existing tests pass
- [x] Manual: `fizzy search "" --tag TAG_ID --all` returns cards across all boards
- [x] Manual: `fizzy search "query" --board BOARD_ID` still scopes correctly when explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Search is now cross-board by default. We removed the implicit default board so results include cards from all boards unless `--board` is set.

- **Bug Fixes**
  - Added tests to ensure no implicit board scope and to assert call count before indexing; removed redundant `searchBoard` assignments in tests.
  - Confirmed `--tag` and `--assignee` filters work cross-board and do not inject `board_ids[]` unless `--board` is passed.

<sup>Written for commit c9c2d91c866054170b14daf0819e263d2a36d617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

