### PR TITLE
fix: use brews instead of homebrew_casks in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,21 +73,23 @@ notarize:
 changelog:
   use: github-native
 
-homebrew_casks:
+brews:
   - name: fizzy
-    ids: [default]
     repository:
       owner: basecamp
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Casks
+    directory: Formula
     homepage: "https://github.com/basecamp/fizzy-cli"
     description: "CLI for managing Fizzy boards, cards, and tasks"
     license: "MIT"
-    completions:
-      bash: "completions/fizzy.bash"
-      zsh: "completions/fizzy.zsh"
-      fish: "completions/fizzy.fish"
+    install: |
+      bin.install "fizzy"
+      bash_completion.install "completions/fizzy.bash" => "fizzy"
+      zsh_completion.install "completions/fizzy.zsh" => "_fizzy"
+      fish_completion.install "completions/fizzy.fish"
+    test: |
+      system "#{bin}/fizzy", "version"
 
 scoops:
   - name: fizzy


### PR DESCRIPTION
## Summary

- Switches GoReleaser config from `homebrew_casks` to `brews`
- Changes output directory from `Casks` to `Formula`
- Replaces the casks-only `completions:` shorthand with an explicit `install:` block (including shell completions for bash, zsh, and fish)
- Adds a `test:` block

## Root cause

`homebrew_casks` is GoReleaser's DSL for macOS GUI apps distributed as `.dmg`/`.pkg` installers. `fizzy` is a CLI binary in a tarball — it should use `brews`, which generates a standard Homebrew Formula. The previous config was generating a Cask and writing it to `Casks/` in the tap, so `brew install basecamp/tap/fizzy` was never resolvable.

## Verification

The generated formula in `dist/homebrew/Formula/fizzy.rb` (produced by `goreleaser release --snapshot --clean`) confirms correct output: platform-specific `on_macos`/`on_linux` blocks, proper binary install, shell completions, and a passing `test` block.

Fixes #107
Fixes #70

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Homebrew publishing for `fizzy` by switching GoReleaser from casks to formulae. This makes `brew install basecamp/tap/fizzy` work as expected.

- **Bug Fixes**
  - Replace `homebrew_casks` with `brews` to generate a Homebrew Formula for the CLI.
  - Output to `Formula/` instead of `Casks/`.
  - Add explicit `install` block to install the binary and completions (bash, zsh, fish).
  - Add a `test` block that runs `fizzy version`.

<sup>Written for commit 1410fc9a9f27d7471e59f2ce1d786b00391a3557. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

