### PR TITLE
fix: auto setup after install is broken, let user run it manually

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,4 +93,4 @@ if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
 fi
 
 echo ""
-"$INSTALL_DIR/${BINARY}" setup || echo "Run '$INSTALL_DIR/${BINARY} setup' to get started."
+echo "Run '$INSTALL_DIR/${BINARY} setup' to get started."


### PR DESCRIPTION
## What
Remove autorun `fizzy setup` after installation (current config file save on the wrong place), instruct user to run it manually.
## Why
Fixes #130 
## Testing

- [x] `make check` passes



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-running `fizzy setup` after install and print a prompt to run it manually. This prevents writing the config to the wrong location and removes the broken post-install step.

- **Bug Fixes**
  - In `scripts/install.sh`, replace the post-install `setup` invocation with: Run '$INSTALL_DIR/${BINARY} setup' to get started.

<sup>Written for commit fe25d77b9f1ae1d991f6b3419dda20d6f7c7e4cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



