### PR TITLE
Bump fizzy SDK to v0.2.2

### DIFF
--- a/SURFACE.txt
+++ b/SURFACE.txt
@@ -144,6 +144,7 @@ CMD fizzy help
 CMD fizzy identity
 CMD fizzy identity help
 CMD fizzy identity show
+CMD fizzy identity timezone-update
 CMD fizzy identity view
 CMD fizzy migrate
 CMD fizzy migrate board
@@ -1979,6 +1980,21 @@ FLAG fizzy identity show --quiet type=bool
 FLAG fizzy identity show --styled type=bool
 FLAG fizzy identity show --token type=string
 FLAG fizzy identity show --verbose type=bool
+FLAG fizzy identity timezone-update --agent type=bool
+FLAG fizzy identity timezone-update --api-url type=string
+FLAG fizzy identity timezone-update --count type=bool
+FLAG fizzy identity timezone-update --help type=bool
+FLAG fizzy identity timezone-update --ids-only type=bool
+FLAG fizzy identity timezone-update --jq type=string
+FLAG fizzy identity timezone-update --json type=bool
+FLAG fizzy identity timezone-update --limit type=int
+FLAG fizzy identity timezone-update --markdown type=bool
+FLAG fizzy identity timezone-update --profile type=string
+FLAG fizzy identity timezone-update --quiet type=bool
+FLAG fizzy identity timezone-update --styled type=bool
+FLAG fizzy identity timezone-update --timezone type=string
+FLAG fizzy identity timezone-update --token type=string
+FLAG fizzy identity timezone-update --verbose type=bool
 FLAG fizzy identity view --agent type=bool
 FLAG fizzy identity view --api-url type=string
 FLAG fizzy identity view --count type=bool
@@ -3435,6 +3451,7 @@ SUB fizzy help
 SUB fizzy identity
 SUB fizzy identity help
 SUB fizzy identity show
+SUB fizzy identity timezone-update
 SUB fizzy identity view
 SUB fizzy migrate
 SUB fizzy migrate board

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/basecamp/cli v0.2.1
-	github.com/basecamp/fizzy-sdk/go v0.2.1
+	github.com/basecamp/fizzy-sdk/go v0.2.2
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/basecamp/cli v0.2.1 h1:8GyehPVtsTXla0oOPu4QgXRjwwzJ99prlByvyi+0HRQ=
 github.com/basecamp/cli v0.2.1/go.mod h1:p8tt/DatJ2LAzWO6N6tNfV8x3gF5T3IxDTo+U8FfWPo=
-github.com/basecamp/fizzy-sdk/go v0.2.1 h1:4xRRBQWP0V5rMkppAramn9bSDILl+zY0RD7ax8IDjKQ=
-github.com/basecamp/fizzy-sdk/go v0.2.1/go.mod h1:XvOTc+2/6NaECvb2mVhIMq2pNsl9P2wNqwvybIUtQ2g=
+github.com/basecamp/fizzy-sdk/go v0.2.2 h1:o2unUWdeJlUlm4L/0Y+/VhLiAjdR9tMNulSyTwFlg+c=
+github.com/basecamp/fizzy-sdk/go v0.2.2/go.mod h1:XvOTc+2/6NaECvb2mVhIMq2pNsl9P2wNqwvybIUtQ2g=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=

--- a/internal/commands/board_test.go
+++ b/internal/commands/board_test.go
@@ -404,8 +404,12 @@ func TestBoardUpdate(t *testing.T) {
 		if mock.PatchCalls[0].Path != "/boards/123" {
 			t.Errorf("expected path '/boards/123', got '%s'", mock.PatchCalls[0].Path)
 		}
-		if got := responseDataMap(t, result)["name"]; got != "Updated Name" {
+		data := responseDataMap(t, result)
+		if got := data["name"]; got != "Updated Name" {
 			t.Errorf("expected update response body name, got %#v", got)
+		}
+		if got := data["id"]; got != "123" {
+			t.Errorf("expected update response body id, got %#v", got)
 		}
 	})
 

--- a/internal/commands/board_test.go
+++ b/internal/commands/board_test.go
@@ -385,7 +385,7 @@ func TestBoardUpdate(t *testing.T) {
 			},
 		}
 
-		SetTestModeWithSDK(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
 		defer resetTest()
 
@@ -403,6 +403,9 @@ func TestBoardUpdate(t *testing.T) {
 		}
 		if mock.PatchCalls[0].Path != "/boards/123" {
 			t.Errorf("expected path '/boards/123', got '%s'", mock.PatchCalls[0].Path)
+		}
+		if got := responseDataMap(t, result)["name"]; got != "Updated Name" {
+			t.Errorf("expected update response body name, got %#v", got)
 		}
 	})
 

--- a/internal/commands/card_test.go
+++ b/internal/commands/card_test.go
@@ -1274,7 +1274,7 @@ func TestCardMove(t *testing.T) {
 			},
 		}
 
-		SetTestModeWithSDK(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
 		defer resetTest()
 
@@ -1293,6 +1293,9 @@ func TestCardMove(t *testing.T) {
 		body := mock.PatchCalls[0].Body.(map[string]any)
 		if body["board_id"] != "board-456" {
 			t.Errorf("expected board_id 'board-456', got '%v'", body["board_id"])
+		}
+		if got := responseDataMap(t, result)["title"]; got != "Test Card" {
+			t.Errorf("expected move response body title, got %#v", got)
 		}
 	})
 

--- a/internal/commands/column_test.go
+++ b/internal/commands/column_test.go
@@ -264,7 +264,7 @@ func TestColumnUpdate(t *testing.T) {
 			},
 		}
 
-		SetTestModeWithSDK(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
 		defer resetTest()
 
@@ -281,6 +281,9 @@ func TestColumnUpdate(t *testing.T) {
 		}
 		if mock.PatchCalls[0].Path != "/boards/123/columns/col-1" {
 			t.Errorf("expected path '/boards/123/columns/col-1', got '%s'", mock.PatchCalls[0].Path)
+		}
+		if got := responseDataMap(t, result)["name"]; got != "Updated Column" {
+			t.Errorf("expected update response body name, got %#v", got)
 		}
 	})
 

--- a/internal/commands/column_test.go
+++ b/internal/commands/column_test.go
@@ -282,8 +282,12 @@ func TestColumnUpdate(t *testing.T) {
 		if mock.PatchCalls[0].Path != "/boards/123/columns/col-1" {
 			t.Errorf("expected path '/boards/123/columns/col-1', got '%s'", mock.PatchCalls[0].Path)
 		}
-		if got := responseDataMap(t, result)["name"]; got != "Updated Column" {
+		data := responseDataMap(t, result)
+		if got := data["name"]; got != "Updated Column" {
 			t.Errorf("expected update response body name, got %#v", got)
+		}
+		if got := data["id"]; got != "col-1" {
+			t.Errorf("expected update response body id, got %#v", got)
 		}
 	})
 

--- a/internal/commands/comment_test.go
+++ b/internal/commands/comment_test.go
@@ -323,7 +323,7 @@ func TestCommentUpdate(t *testing.T) {
 			},
 		}
 
-		SetTestModeWithSDK(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
 		defer resetTest()
 
@@ -340,6 +340,13 @@ func TestCommentUpdate(t *testing.T) {
 		}
 		if mock.PatchCalls[0].Path != "/cards/42/comments/comment-1" {
 			t.Errorf("expected path '/cards/42/comments/comment-1', got '%s'", mock.PatchCalls[0].Path)
+		}
+		body, ok := responseDataMap(t, result)["body"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected update response body map, got %#v", responseDataMap(t, result)["body"])
+		}
+		if got := body["plain_text"]; got != "Updated comment" {
+			t.Errorf("expected update response body plain_text, got %#v", got)
 		}
 	})
 

--- a/internal/commands/identity.go
+++ b/internal/commands/identity.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/basecamp/fizzy-sdk/go/pkg/generated"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,40 @@ var identityShowCmd = &cobra.Command{
 	},
 }
 
+var identityTimezoneUpdateTimezone string
+
+var identityTimezoneUpdateCmd = &cobra.Command{
+	Use:   "timezone-update",
+	Short: "Update your timezone",
+	Long:  "Updates your timezone for the current account.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAuthAndAccount(); err != nil {
+			return err
+		}
+
+		if identityTimezoneUpdateTimezone == "" {
+			return newRequiredFlagError("timezone")
+		}
+
+		_, err := getSDKClient().Identity().UpdateMyTimezone(cmd.Context(), cfg.Account, &generated.UpdateMyTimezoneRequest{
+			TimezoneName: identityTimezoneUpdateTimezone,
+		})
+		if err != nil {
+			return convertSDKError(err)
+		}
+
+		breadcrumbs := []Breadcrumb{
+			breadcrumb("show", "fizzy identity show", "View identity"),
+		}
+
+		printMutation(map[string]any{"timezone_name": identityTimezoneUpdateTimezone}, "Timezone updated", breadcrumbs)
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(identityCmd)
 	identityCmd.AddCommand(identityShowCmd)
+	identityTimezoneUpdateCmd.Flags().StringVar(&identityTimezoneUpdateTimezone, "timezone", "", "Timezone name, for example America/New_York (required)")
+	identityCmd.AddCommand(identityTimezoneUpdateCmd)
 }

--- a/internal/commands/identity.go
+++ b/internal/commands/identity.go
@@ -53,18 +53,25 @@ var identityTimezoneUpdateCmd = &cobra.Command{
 			return newRequiredFlagError("timezone")
 		}
 
-		_, err := getSDKClient().Identity().UpdateMyTimezone(cmd.Context(), cfg.Account, &generated.UpdateMyTimezoneRequest{
+		resp, err := getSDKClient().Identity().UpdateMyTimezone(cmd.Context(), cfg.Account, &generated.UpdateMyTimezoneRequest{
 			TimezoneName: identityTimezoneUpdateTimezone,
 		})
 		if err != nil {
 			return convertSDKError(err)
 		}
 
+		data := any(map[string]any{"timezone_name": identityTimezoneUpdateTimezone})
+		if resp != nil && len(resp.Data) > 0 {
+			if normalized := normalizeAny(resp.Data); normalized != nil {
+				data = normalized
+			}
+		}
+
 		breadcrumbs := []Breadcrumb{
 			breadcrumb("show", "fizzy identity show", "View identity"),
 		}
 
-		printMutation(map[string]any{"timezone_name": identityTimezoneUpdateTimezone}, "Timezone updated", breadcrumbs)
+		printMutation(data, "Timezone updated", breadcrumbs)
 		return nil
 	},
 }

--- a/internal/commands/identity_test.go
+++ b/internal/commands/identity_test.go
@@ -10,7 +10,13 @@ import (
 func TestIdentityTimezoneUpdate(t *testing.T) {
 	t.Run("updates timezone", func(t *testing.T) {
 		mock := NewMockClient()
-		mock.PatchResponse = &client.APIResponse{StatusCode: 204, Data: nil}
+		mock.PatchResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data: map[string]any{
+				"timezone_name": "America/New_York",
+				"updated_at":    "2026-06-03T21:15:00Z",
+			},
+		}
 
 		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
@@ -41,6 +47,29 @@ func TestIdentityTimezoneUpdate(t *testing.T) {
 		}
 		if result.Response.Summary != "Timezone updated" {
 			t.Errorf("expected timezone summary, got %q", result.Response.Summary)
+		}
+		if got := responseDataMap(t, result)["updated_at"]; got != "2026-06-03T21:15:00Z" {
+			t.Errorf("expected timezone response body updated_at, got %#v", got)
+		}
+	})
+
+	t.Run("falls back to requested timezone for empty response", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PatchResponse = &client.APIResponse{StatusCode: 204, Data: nil}
+
+		result := SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		identityTimezoneUpdateTimezone = "America/New_York"
+		defer func() {
+			identityTimezoneUpdateTimezone = ""
+			resetTest()
+		}()
+
+		err := identityTimezoneUpdateCmd.RunE(identityTimezoneUpdateCmd, []string{})
+		assertExitCode(t, err, 0)
+
+		if got := responseDataMap(t, result)["timezone_name"]; got != "America/New_York" {
+			t.Errorf("expected fallback timezone_name, got %#v", got)
 		}
 	})
 

--- a/internal/commands/identity_test.go
+++ b/internal/commands/identity_test.go
@@ -7,6 +7,69 @@ import (
 	"github.com/basecamp/fizzy-cli/internal/errors"
 )
 
+func TestIdentityTimezoneUpdate(t *testing.T) {
+	t.Run("updates timezone", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PatchResponse = &client.APIResponse{StatusCode: 204, Data: nil}
+
+		result := SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		identityTimezoneUpdateTimezone = "America/New_York"
+		defer func() {
+			identityTimezoneUpdateTimezone = ""
+			resetTest()
+		}()
+
+		err := identityTimezoneUpdateCmd.RunE(identityTimezoneUpdateCmd, []string{})
+		assertExitCode(t, err, 0)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(mock.PatchCalls) != 1 {
+			t.Fatalf("expected 1 patch call, got %d", len(mock.PatchCalls))
+		}
+		if mock.PatchCalls[0].Path != "/my/timezone.json" {
+			t.Errorf("expected path '/my/timezone.json', got %q", mock.PatchCalls[0].Path)
+		}
+		body, ok := mock.PatchCalls[0].Body.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map body, got %#v", mock.PatchCalls[0].Body)
+		}
+		if body["timezone_name"] != "America/New_York" {
+			t.Errorf("expected timezone_name body, got %#v", body)
+		}
+		if result.Response.Summary != "Timezone updated" {
+			t.Errorf("expected timezone summary, got %q", result.Response.Summary)
+		}
+	})
+
+	t.Run("requires timezone", func(t *testing.T) {
+		mock := NewMockClient()
+		SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		identityTimezoneUpdateTimezone = ""
+		defer resetTest()
+
+		err := identityTimezoneUpdateCmd.RunE(identityTimezoneUpdateCmd, []string{})
+		assertExitCode(t, err, errors.ExitInvalidArgs)
+	})
+
+	t.Run("requires account", func(t *testing.T) {
+		mock := NewMockClient()
+		SetTestModeWithSDK(mock)
+		SetTestConfig("token", "", "https://api.example.com")
+		identityTimezoneUpdateTimezone = "America/New_York"
+		defer func() {
+			identityTimezoneUpdateTimezone = ""
+			resetTest()
+		}()
+
+		err := identityTimezoneUpdateCmd.RunE(identityTimezoneUpdateCmd, []string{})
+		assertExitCode(t, err, errors.ExitInvalidArgs)
+	})
+}
+
 func TestIdentityShow(t *testing.T) {
 	t.Run("shows identity", func(t *testing.T) {
 		mock := NewMockClient()

--- a/internal/commands/response_assertions_test.go
+++ b/internal/commands/response_assertions_test.go
@@ -1,0 +1,15 @@
+package commands
+
+import "testing"
+
+func responseDataMap(t *testing.T, result *CommandResult) map[string]any {
+	t.Helper()
+	if result == nil || result.Response == nil {
+		t.Fatal("expected command response")
+	}
+	data, ok := result.Response.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected response data map, got %#v", result.Response.Data)
+	}
+	return data
+}

--- a/internal/commands/user_test.go
+++ b/internal/commands/user_test.go
@@ -80,11 +80,14 @@ func TestUserUpdate(t *testing.T) {
 	t.Run("updates user name", func(t *testing.T) {
 		mock := NewMockClient()
 		mock.PatchResponse = &client.APIResponse{
-			StatusCode: 204,
-			Data:       map[string]any{},
+			StatusCode: 200,
+			Data: map[string]any{
+				"id":   "user-1",
+				"name": "New Name",
+			},
 		}
 
-		SetTestModeWithSDK(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
 		defer resetTest()
 
@@ -103,6 +106,9 @@ func TestUserUpdate(t *testing.T) {
 		body := mock.PatchCalls[0].Body.(map[string]any)
 		if body["name"] != "New Name" {
 			t.Errorf("expected name 'New Name', got '%v'", body["name"])
+		}
+		if got := responseDataMap(t, result)["name"]; got != "New Name" {
+			t.Errorf("expected update response body name, got %#v", got)
 		}
 	})
 

--- a/internal/commands/user_test.go
+++ b/internal/commands/user_test.go
@@ -107,8 +107,12 @@ func TestUserUpdate(t *testing.T) {
 		if body["name"] != "New Name" {
 			t.Errorf("expected name 'New Name', got '%v'", body["name"])
 		}
-		if got := responseDataMap(t, result)["name"]; got != "New Name" {
+		data := responseDataMap(t, result)
+		if got := data["name"]; got != "New Name" {
 			t.Errorf("expected update response body name, got %#v", got)
+		}
+		if got := data["id"]; got != "user-1" {
+			t.Errorf("expected update response body id, got %#v", got)
 		}
 	})
 

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -100,6 +100,7 @@ Want to change something?
 | Resource | List | Show | Create | Update | Delete | Other |
 |----------|------|------|--------|--------|--------|-------|
 | account | - | `account show` | - | `account settings-update` | - | `account entropy`, `account export-create`, `account export-show EXPORT_ID`, `account join-code-show`, `account join-code-reset`, `account join-code-update` |
+| identity | - | `identity show` | - | `identity timezone-update --timezone NAME` | - | - |
 | board | `board list` | `board show ID` | `board create` | `board update ID` | `board delete ID` | `board accesses --board ID`, `board publish ID`, `board unpublish ID`, `board entropy ID`, `board closed`, `board postponed`, `board stream`, `board involvement ID`, `migrate board ID` |
 | card | `card list` | `card show NUMBER` | `card create` | `card update NUMBER` | `card delete NUMBER` | `card move NUMBER`, `card publish NUMBER`, `card mark-read NUMBER`, `card mark-unread NUMBER` |
 | search | `search QUERY` | - | - | - | - | - |
@@ -455,6 +456,7 @@ fizzy comment list --card 579 --jq '.data | length'
 
 ```bash
 fizzy identity show                    # Show your identity and accessible accounts
+fizzy identity timezone-update --timezone America/New_York  # Update your timezone for the current account
 ```
 
 ### Account


### PR DESCRIPTION
## Summary
- bump github.com/basecamp/fizzy-sdk/go to v0.2.2
- add `fizzy identity timezone-update --timezone NAME` for the new timezone SDK operation
- assert mutation response bodies from SDK-backed update/move commands are surfaced by the CLI
- update SURFACE.txt and the Fizzy skill docs

## Tests
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- GOWORK=off go build -o bin/fizzy ./cmd/fizzy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fizzy identity timezone-update` and ensures SDK-backed update/move commands surface mutation response bodies, with a fallback to requested values when the API returns no body.

- **New Features**
  - `identity timezone-update` to set your timezone for the current account (requires `--timezone`, e.g., America/New_York)

- **Dependencies**
  - Update `github.com/basecamp/fizzy-sdk/go` to v0.2.2

<sup>Written for commit b2155ebe286155ebfc160de9c62796505b73723a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

