### PR TITLE
Use cosign bundle for release checksum signing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,11 +49,12 @@ signs:
   - cmd: cosign
     artifacts: checksum
     output: true
+    signature: "${artifact}.bundle"
     args:
       - sign-blob
       - --yes
-      - --output-certificate=${certificate}
-      - --output-signature=${signature}
+      - --new-bundle-format=true
+      - --bundle=${signature}
       - ${artifact}
 
 notarize:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@ Pushing the tag triggers the GitHub Actions release workflow, which:
 1. Runs the full test suite
 2. Builds binaries for all platforms (linux/darwin/windows/freebsd/openbsd x amd64/arm64)
 3. Signs macOS binaries (Developer ID + notarization)
-4. Signs checksums with cosign (keyless, OIDC)
+4. Signs checksums with a cosign keyless bundle (OIDC)
 5. Generates SBOMs with Syft
 6. Builds .deb and .rpm packages
 7. For stable tags only, publishes the Homebrew cask to `basecamp/homebrew-tap`


### PR DESCRIPTION
## Summary
- updates GoReleaser checksum signing to emit a cosign bundle
- documents checksum signing as a cosign keyless bundle

## Validation
- GOWORK=off go run github.com/goreleaser/goreleaser/v2@v2.14.1 check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release checksum signing to a `cosign` keyless bundle to improve verification and portability. `goreleaser` now emits a single `.bundle` per checksum and docs reflect the new flow.

- **Migration**
  - Update verification to use `cosign verify-blob --bundle <checksum-file>.bundle <checksum-file>`.
  - Expect `.bundle` files instead of separate signature/certificate outputs.

<sup>Written for commit 31210e00d5502b802f649e188eafdfd15f592937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

