### PR TITLE
Use current attest checksums input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-checksums-file: ./dist/checksums.txt
+          subject-checksums: ./dist/checksums.txt
 
   aur-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- updates the release provenance attestation step to use the current `subject-checksums` input

## Validation
- git diff --check

Note: v4.0.0-rc.3 published release assets successfully, then failed on this attestation input.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the release provenance attestation step to use the current `subject-checksums` input in `actions/attest-build-provenance`. Fixes the attestation failure that occurred after publishing release assets.

<sup>Written for commit b53170c7b6b4be0a946551d7d7f829c0d6db066b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

