### PR TITLE
Add interactive update notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Configuration priority (highest to lowest):
 
 `FIZZY_ACCOUNT` is accepted as a deprecated alias for `FIZZY_PROFILE`.
 
+`FIZZY_NO_UPDATE_NOTIFIER=1` runs commands without update notifications.
+
 Inspect the effective config and precedence:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/hashicorp/go-version v1.7.0
 	github.com/itchyny/gojq v0.12.19
 	github.com/mattn/go-isatty v0.0.22
 	github.com/muesli/termenv v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -171,6 +171,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		startUpdateCheck()
 		return nil
 	},
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
@@ -182,6 +183,7 @@ var rootCmd = &cobra.Command{
 		if RefreshSkillsIfVersionChanged() && !IsMachineOutput() {
 			fmt.Fprintf(os.Stderr, "Agent skill updated to match CLI %s\n", currentVersion())
 		}
+		finishUpdateCheck()
 		return nil
 	},
 	SilenceUsage:  true,
@@ -1384,6 +1386,11 @@ func ResetTestMode() {
 	cfgLimit = 0
 	cfgJQ = ""
 	cfgProfile = ""
+	if updateCancel != nil {
+		updateCancel()
+	}
+	updateCancel = nil
+	updateMessage = nil
 }
 
 // GetRootCmd returns the root command for testing.

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1391,6 +1391,8 @@ func ResetTestMode() {
 	}
 	updateCancel = nil
 	updateMessage = nil
+	machineOutputChecker = IsMachineOutput
+	terminalChecker = isTerminal
 }
 
 // GetRootCmd returns the root command for testing.

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -136,6 +136,9 @@ func checkForUpdate(ctx context.Context, client *http.Client, stateFilePath, cur
 		stateEntry = nil
 	}
 	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
+		if versionGreaterThan(stateEntry.LatestRelease.Version, currentVersion) {
+			return &stateEntry.LatestRelease, nil
+		}
 		return nil, nil
 	}
 
@@ -160,6 +163,7 @@ func getLatestReleaseInfo(ctx context.Context, client *http.Client, repo string)
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "fizzy-cli/"+currentVersion())
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -1,0 +1,244 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basecamp/fizzy-cli/internal/config"
+	version "github.com/hashicorp/go-version"
+	"github.com/mattn/go-isatty"
+	"gopkg.in/yaml.v3"
+)
+
+const fizzyUpdateRepo = "basecamp/fizzy-cli"
+
+var gitDescribeSuffixRE = regexp.MustCompile(`\d+-\d+-g[a-f0-9]{8}$`)
+
+var (
+	updateHTTPClient = &http.Client{Timeout: 5 * time.Second}
+	updateCancel     context.CancelFunc
+	updateMessage    chan *releaseInfo
+)
+
+type releaseInfo struct {
+	Version     string    `json:"tag_name" yaml:"version"`
+	URL         string    `json:"html_url" yaml:"url"`
+	PublishedAt time.Time `json:"published_at" yaml:"published_at"`
+}
+
+type updateStateEntry struct {
+	CheckedForUpdateAt time.Time   `yaml:"checked_for_update_at"`
+	LatestRelease      releaseInfo `yaml:"latest_release"`
+}
+
+func startUpdateCheck() {
+	if updateCancel != nil {
+		updateCancel()
+		updateCancel = nil
+		updateMessage = nil
+	}
+
+	current := currentVersion()
+	if !isUpdateableVersion(current) || !shouldCheckForUpdate() {
+		return
+	}
+
+	stateDir, err := config.StateDir()
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is retained and called after command execution
+	updateCancel = cancel
+	updateMessage = make(chan *releaseInfo, 1)
+	go func() {
+		rel, err := checkForUpdate(ctx, updateHTTPClient, filepath.Join(stateDir, "state.yml"), fizzyUpdateRepo, current)
+		if err != nil && cfgVerbose {
+			fmt.Fprintf(os.Stderr, "warning: checking for update failed: %v\n", err)
+		}
+		updateMessage <- rel
+	}()
+}
+
+func finishUpdateCheck() {
+	if updateCancel == nil || updateMessage == nil {
+		return
+	}
+
+	updateCancel()
+	rel := <-updateMessage
+	updateCancel = nil
+	updateMessage = nil
+	if rel == nil {
+		return
+	}
+
+	exe, _ := os.Executable()
+	isHomebrew := isUnderHomebrew(exe)
+	if isHomebrew && isRecentRelease(rel.PublishedAt) {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "\n\nA new release of fizzy is available: %s → %s\n",
+		strings.TrimPrefix(currentVersion(), "v"),
+		strings.TrimPrefix(rel.Version, "v"))
+	if isHomebrew {
+		fmt.Fprintln(os.Stderr, "To upgrade, run: brew upgrade basecamp/tap/fizzy")
+	} else {
+		fmt.Fprintln(os.Stderr, "Upgrade with your package manager, or download it from:")
+	}
+	fmt.Fprintf(os.Stderr, "%s\n\n", rel.URL)
+}
+
+func shouldCheckForUpdate() bool {
+	if os.Getenv("FIZZY_NO_UPDATE_NOTIFIER") != "" {
+		return false
+	}
+	if os.Getenv("CODESPACES") != "" {
+		return false
+	}
+	if isCI() {
+		return false
+	}
+	if cfgAgent || cfgJSON || cfgQuiet || cfgIDsOnly || cfgCount || cfgJQ != "" {
+		return false
+	}
+	return isTerminal(os.Stdout) && isTerminal(os.Stderr)
+}
+
+func checkForUpdate(ctx context.Context, client *http.Client, stateFilePath, repo, currentVersion string) (*releaseInfo, error) {
+	stateEntry, _ := getUpdateStateEntry(stateFilePath)
+	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
+		return nil, nil
+	}
+
+	rel, err := getLatestReleaseInfo(ctx, client, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setUpdateStateEntry(stateFilePath, time.Now(), *rel); err != nil {
+		return nil, err
+	}
+
+	if versionGreaterThan(rel.Version, currentVersion) {
+		return rel, nil
+	}
+	return nil, nil
+}
+
+func getLatestReleaseInfo(ctx context.Context, client *http.Client, repo string) (*releaseInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP %d", res.StatusCode)
+	}
+
+	var rel releaseInfo
+	if err := json.NewDecoder(io.LimitReader(res.Body, 1<<20)).Decode(&rel); err != nil {
+		return nil, err
+	}
+	return &rel, nil
+}
+
+func getUpdateStateEntry(stateFilePath string) (*updateStateEntry, error) {
+	content, err := os.ReadFile(stateFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var stateEntry updateStateEntry
+	if err := yaml.Unmarshal(content, &stateEntry); err != nil {
+		return nil, err
+	}
+	return &stateEntry, nil
+}
+
+func setUpdateStateEntry(stateFilePath string, t time.Time, rel releaseInfo) error {
+	content, err := yaml.Marshal(updateStateEntry{CheckedForUpdateAt: t, LatestRelease: rel})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(stateFilePath), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(stateFilePath, content, 0o600)
+}
+
+func versionGreaterThan(v, w string) bool {
+	w = gitDescribeSuffixRE.ReplaceAllStringFunc(w, func(m string) string {
+		idx := strings.IndexRune(m, '-')
+		n, _ := strconv.Atoi(m[:idx])
+		return fmt.Sprintf("%d-pre.0", n+1)
+	})
+
+	vv, ve := version.NewVersion(v)
+	vw, we := version.NewVersion(w)
+	return ve == nil && we == nil && vv.GreaterThan(vw)
+}
+
+func isUpdateableVersion(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "dev" || strings.Contains(v, "dirty") || strings.Contains(v, "-g") {
+		return false
+	}
+	_, err := version.NewVersion(v)
+	return err == nil
+}
+
+func isRecentRelease(publishedAt time.Time) bool {
+	return !publishedAt.IsZero() && time.Since(publishedAt) < 24*time.Hour
+}
+
+func isUnderHomebrew(exePath string) bool {
+	if exePath == "" {
+		return false
+	}
+	brewExe, err := exec.LookPath("brew")
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	prefix, err := exec.CommandContext(ctx, brewExe, "--prefix").Output() //nolint:gosec // G204: brewExe comes from exec.LookPath
+	if err != nil {
+		return false
+	}
+	brewBinPrefix := filepath.Join(strings.TrimSpace(string(prefix)), "bin") + string(filepath.Separator)
+	return strings.HasPrefix(exePath, brewBinPrefix)
+}
+
+func isCI() bool {
+	for _, name := range []string{"CI", "GITHUB_ACTIONS", "BUILDKITE", "CIRCLECI", "GITLAB_CI", "JENKINS_URL", "TEAMCITY_VERSION", "TF_BUILD"} {
+		if os.Getenv(name) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -128,7 +129,11 @@ func shouldCheckForUpdate() bool {
 func checkForUpdate(ctx context.Context, client *http.Client, stateFilePath, currentVersion string) (*releaseInfo, error) {
 	stateEntry, err := getUpdateStateEntry(stateFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, err
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			return nil, err
+		}
+		stateEntry = nil
 	}
 	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
 		return nil, nil

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -25,9 +25,11 @@ const fizzyUpdateRepo = "basecamp/fizzy-cli"
 var gitDescribeSuffixRE = regexp.MustCompile(`\d+-\d+-g[a-f0-9]{8}$`)
 
 var (
-	updateHTTPClient = &http.Client{Timeout: 5 * time.Second}
-	updateCancel     context.CancelFunc
-	updateMessage    chan *releaseInfo
+	updateHTTPClient     = &http.Client{Timeout: 5 * time.Second}
+	updateCancel         context.CancelFunc
+	updateMessage        chan *releaseInfo
+	machineOutputChecker = IsMachineOutput
+	terminalChecker      = isTerminal
 )
 
 type releaseInfo struct {
@@ -60,13 +62,14 @@ func startUpdateCheck() {
 
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is retained and called after command execution
 	updateCancel = cancel
-	updateMessage = make(chan *releaseInfo, 1)
+	message := make(chan *releaseInfo, 1)
+	updateMessage = message
 	go func() {
-		rel, err := checkForUpdate(ctx, updateHTTPClient, filepath.Join(stateDir, "state.yml"), fizzyUpdateRepo, current)
+		rel, err := checkForUpdate(ctx, updateHTTPClient, filepath.Join(stateDir, "state.yml"), current)
 		if err != nil && cfgVerbose {
 			fmt.Fprintf(os.Stderr, "warning: checking for update failed: %v\n", err)
 		}
-		updateMessage <- rel
+		message <- rel
 	}()
 }
 
@@ -75,8 +78,14 @@ func finishUpdateCheck() {
 		return
 	}
 
-	updateCancel()
-	rel := <-updateMessage
+	cancel := updateCancel
+	message := updateMessage
+	var rel *releaseInfo
+	select {
+	case rel = <-message:
+	case <-time.After(200 * time.Millisecond):
+	}
+	cancel()
 	updateCancel = nil
 	updateMessage = nil
 	if rel == nil {
@@ -89,7 +98,7 @@ func finishUpdateCheck() {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "\n\nA new release of fizzy is available: %s → %s\n",
+	fmt.Fprintf(os.Stderr, "\n\nA new release of Fizzy is available: %s → %s\n",
 		strings.TrimPrefix(currentVersion(), "v"),
 		strings.TrimPrefix(rel.Version, "v"))
 	if isHomebrew {
@@ -110,19 +119,22 @@ func shouldCheckForUpdate() bool {
 	if isCI() {
 		return false
 	}
-	if cfgAgent || cfgJSON || cfgQuiet || cfgIDsOnly || cfgCount || cfgJQ != "" {
+	if machineOutputChecker() {
 		return false
 	}
-	return isTerminal(os.Stdout) && isTerminal(os.Stderr)
+	return terminalChecker(os.Stderr)
 }
 
-func checkForUpdate(ctx context.Context, client *http.Client, stateFilePath, repo, currentVersion string) (*releaseInfo, error) {
-	stateEntry, _ := getUpdateStateEntry(stateFilePath)
+func checkForUpdate(ctx context.Context, client *http.Client, stateFilePath, currentVersion string) (*releaseInfo, error) {
+	stateEntry, err := getUpdateStateEntry(stateFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
 	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
 		return nil, nil
 	}
 
-	rel, err := getLatestReleaseInfo(ctx, client, repo)
+	rel, err := getLatestReleaseInfo(ctx, client, fizzyUpdateRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/update_test.go
+++ b/internal/commands/update_test.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestCheckForUpdateFindsNewRelease(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.yml")
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != "https://api.github.com/repos/basecamp/fizzy-cli/releases/latest" {
+			t.Fatalf("unexpected URL %s", req.URL.String())
+		}
+		body := `{"tag_name":"v3.0.3","html_url":"https://github.com/basecamp/fizzy-cli/releases/tag/v3.0.3","published_at":"2026-03-02T21:19:42Z"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}
+
+	rel, err := checkForUpdate(context.Background(), client, stateFile, "basecamp/fizzy-cli", "v3.0.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rel == nil || rel.Version != "v3.0.3" {
+		t.Fatalf("release = %#v, want v3.0.3", rel)
+	}
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("state file not written: %v", err)
+	}
+}
+
+func TestCheckForUpdateSkipsRecentState(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.yml")
+	err := setUpdateStateEntry(stateFile, time.Now().Add(-time.Hour), releaseInfo{Version: "v3.0.3"})
+	if err != nil {
+		t.Fatalf("failed to write state: %v", err)
+	}
+
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+	})}
+
+	rel, err := checkForUpdate(context.Background(), client, stateFile, "basecamp/fizzy-cli", "v3.0.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rel != nil {
+		t.Fatalf("release = %#v, want nil", rel)
+	}
+	if called {
+		t.Fatal("expected recent state to skip HTTP request")
+	}
+}
+
+func TestVersionGreaterThan(t *testing.T) {
+	tests := []struct {
+		latest  string
+		current string
+		want    bool
+	}{
+		{"v3.0.3", "v3.0.2", true},
+		{"v3.0.3", "v3.0.3", false},
+		{"v3.0.2", "v3.0.3", false},
+		{"v3.1.0", "v3.1.0-2-gabcdef12", false},
+		{"v3.1.1", "v3.1.0-2-gabcdef12", true},
+		{"v3.0.3", "dev", false},
+	}
+
+	for _, tt := range tests {
+		if got := versionGreaterThan(tt.latest, tt.current); got != tt.want {
+			t.Fatalf("versionGreaterThan(%q, %q) = %v, want %v", tt.latest, tt.current, got, tt.want)
+		}
+	}
+}
+
+func TestShouldCheckForUpdateHonorsOptOut(t *testing.T) {
+	t.Setenv("FIZZY_NO_UPDATE_NOTIFIER", "1")
+	if shouldCheckForUpdate() {
+		t.Fatal("expected FIZZY_NO_UPDATE_NOTIFIER to disable update checks")
+	}
+}

--- a/internal/commands/update_test.go
+++ b/internal/commands/update_test.go
@@ -23,6 +23,9 @@ func TestCheckForUpdateFindsNewRelease(t *testing.T) {
 		if req.URL.String() != "https://api.github.com/repos/basecamp/fizzy-cli/releases/latest" {
 			t.Fatalf("unexpected URL %s", req.URL.String())
 		}
+		if ua := req.Header.Get("User-Agent"); ua != "fizzy-cli/"+currentVersion() {
+			t.Fatalf("User-Agent = %q, want fizzy-cli/%s", ua, currentVersion())
+		}
 		body := `{"tag_name":"v3.0.3","html_url":"https://github.com/basecamp/fizzy-cli/releases/tag/v3.0.3","published_at":"2026-03-02T21:19:42Z"}`
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
 	})}
@@ -64,7 +67,7 @@ func TestCheckForUpdateRecoversCorruptState(t *testing.T) {
 	}
 }
 
-func TestCheckForUpdateSkipsRecentState(t *testing.T) {
+func TestCheckForUpdateUsesRecentCachedRelease(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state.yml")
 	err := setUpdateStateEntry(stateFile, time.Now().Add(-time.Hour), releaseInfo{Version: "v3.0.3"})
 	if err != nil {
@@ -78,6 +81,31 @@ func TestCheckForUpdateSkipsRecentState(t *testing.T) {
 	})}
 
 	rel, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rel == nil || rel.Version != "v3.0.3" {
+		t.Fatalf("release = %#v, want cached v3.0.3", rel)
+	}
+	if called {
+		t.Fatal("expected recent state to skip HTTP request")
+	}
+}
+
+func TestCheckForUpdateSkipsCurrentCachedRelease(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.yml")
+	err := setUpdateStateEntry(stateFile, time.Now().Add(-time.Hour), releaseInfo{Version: "v3.0.3"})
+	if err != nil {
+		t.Fatalf("failed to write state: %v", err)
+	}
+
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+	})}
+
+	rel, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.3")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/commands/update_test.go
+++ b/internal/commands/update_test.go
@@ -39,7 +39,7 @@ func TestCheckForUpdateFindsNewRelease(t *testing.T) {
 	}
 }
 
-func TestCheckForUpdateReturnsStateReadErrors(t *testing.T) {
+func TestCheckForUpdateRecoversCorruptState(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state.yml")
 	if err := os.WriteFile(stateFile, []byte("checked_for_update_at: ["), 0o600); err != nil {
 		t.Fatalf("failed to write state: %v", err)
@@ -48,15 +48,19 @@ func TestCheckForUpdateReturnsStateReadErrors(t *testing.T) {
 	called := false
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		called = true
-		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+		body := `{"tag_name":"v3.0.3","html_url":"https://github.com/basecamp/fizzy-cli/releases/tag/v3.0.3","published_at":"2026-03-02T21:19:42Z"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
 	})}
 
-	_, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.2")
-	if err == nil {
-		t.Fatal("expected state read error")
+	rel, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if called {
-		t.Fatal("expected state read error to skip HTTP request")
+	if !called {
+		t.Fatal("expected corrupt state to fetch latest release")
+	}
+	if rel == nil || rel.Version != "v3.0.3" {
+		t.Fatalf("release = %#v, want v3.0.3", rel)
 	}
 }
 

--- a/internal/commands/update_test.go
+++ b/internal/commands/update_test.go
@@ -27,7 +27,7 @@ func TestCheckForUpdateFindsNewRelease(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
 	})}
 
-	rel, err := checkForUpdate(context.Background(), client, stateFile, "basecamp/fizzy-cli", "v3.0.2")
+	rel, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.2")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -36,6 +36,27 @@ func TestCheckForUpdateFindsNewRelease(t *testing.T) {
 	}
 	if _, err := os.Stat(stateFile); err != nil {
 		t.Fatalf("state file not written: %v", err)
+	}
+}
+
+func TestCheckForUpdateReturnsStateReadErrors(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.yml")
+	if err := os.WriteFile(stateFile, []byte("checked_for_update_at: ["), 0o600); err != nil {
+		t.Fatalf("failed to write state: %v", err)
+	}
+
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+	})}
+
+	_, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.2")
+	if err == nil {
+		t.Fatal("expected state read error")
+	}
+	if called {
+		t.Fatal("expected state read error to skip HTTP request")
 	}
 }
 
@@ -52,7 +73,7 @@ func TestCheckForUpdateSkipsRecentState(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
 	})}
 
-	rel, err := checkForUpdate(context.Background(), client, stateFile, "basecamp/fizzy-cli", "v3.0.2")
+	rel, err := checkForUpdate(context.Background(), client, stateFile, "v3.0.2")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -86,6 +107,20 @@ func TestVersionGreaterThan(t *testing.T) {
 }
 
 func TestShouldCheckForUpdateHonorsOptOut(t *testing.T) {
+	for _, name := range []string{"CODESPACES", "CI", "GITHUB_ACTIONS", "BUILDKITE", "CIRCLECI", "GITLAB_CI", "JENKINS_URL", "TEAMCITY_VERSION", "TF_BUILD"} {
+		t.Setenv(name, "")
+	}
+	machineOutputChecker = func() bool { return false }
+	terminalChecker = func(*os.File) bool { return true }
+	defer func() {
+		machineOutputChecker = IsMachineOutput
+		terminalChecker = isTerminal
+	}()
+
+	if !shouldCheckForUpdate() {
+		t.Fatal("expected update checks to be enabled before opt-out")
+	}
+
 	t.Setenv("FIZZY_NO_UPDATE_NOTIFIER", "1")
 	if shouldCheckForUpdate() {
 		t.Fatal("expected FIZZY_NO_UPDATE_NOTIFIER to disable update checks")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,13 +247,12 @@ func StateDir() (string, error) {
 		return testConfigDir, nil
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
 	base := os.Getenv("XDG_STATE_HOME")
 	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
 		base = filepath.Join(home, ".local", "state")
 	}
 	dir := filepath.Join(base, "fizzy")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,6 +238,31 @@ func ConfigPath() (string, error) {
 	return preferred, nil
 }
 
+// StateDir returns the directory where Fizzy stores command state.
+func StateDir() (string, error) {
+	if testConfigDir != "" {
+		if err := os.MkdirAll(testConfigDir, 0o700); err != nil {
+			return "", err
+		}
+		return testConfigDir, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		base = filepath.Join(home, ".local", "state")
+	}
+	dir := filepath.Join(base, "fizzy")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 // Save saves the configuration to the global config file.
 func (c *Config) Save() error {
 	path, err := ConfigPath()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -674,6 +674,24 @@ func TestSetTestConfigDir(t *testing.T) {
 	}
 }
 
+func TestStateDirUsesXDGStateHome(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	dir, err := StateDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := filepath.Join(stateHome, "fizzy")
+	if dir != expected {
+		t.Fatalf("StateDir() = %q, want %q", dir, expected)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("state dir not created: %v", err)
+	}
+}
+
 func TestHTTPWarning(t *testing.T) {
 	t.Run("warns on non-localhost HTTP URL", func(t *testing.T) {
 		// Capture stderr


### PR DESCRIPTION
Adds an interactive notification when a newer Fizzy CLI release is available, so users are aware of updates without needing to manually check GitHub releases. The notification stays out of machine-readable output, supports `FIZZY_NO_UPDATE_NOTIFIER=1`, and includes an upgrade hint when appropriate.

Closes #153.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an interactive update notifier that checks GitHub for newer Fizzy CLI releases and shows a short upgrade hint in TTY sessions only. Runs in the background and never blocks the command; closes #153.

- **New Features**
  - Checks GitHub Releases asynchronously and prints after the command finishes (waits up to 200ms).
  - Uses a 24h cache at ~/.local/state/fizzy/state.yml (or $XDG_STATE_HOME/fizzy); recovers from corrupt state and serves notices from cache without network within TTL.
  - Only shows in interactive TTYs; skips CI/Codespaces, machine-output modes, and non-release builds; opt out with `FIZZY_NO_UPDATE_NOTIFIER=1`.
  - Detects Homebrew installs; suppresses notices for <24h-old releases and shows `brew upgrade basecamp/tap/fizzy` when applicable.

- **Dependencies**
  - Add `github.com/hashicorp/go-version` for SemVer parsing and comparison.

<sup>Written for commit c546e4f963cad8a24d109351c57ff8b7a2562ee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

