### PR TITLE
Document Homebrew transition for Fizzy 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ Latest stable Fizzy 3.x is available from the original tap:
 brew install robzolkos/fizzy-cli/fizzy-cli
 ```
 
-Fizzy 4 release candidates are available from [Releases](https://github.com/basecamp/fizzy-cli/releases). Fizzy 4 stable will be published from Basecamp's Homebrew tap:
+Fizzy 4 release candidates are available from [Releases](https://github.com/basecamp/fizzy-cli/releases).
 
-```bash
-brew install --cask basecamp/tap/fizzy
-```
+> [!WARNING]
+> The Basecamp Homebrew tap command is for Fizzy 4 stable once it is released. Release candidates are not published to Homebrew.
+>
+> ```bash
+> brew install --cask basecamp/tap/fizzy
+> ```
 
 **Scoop (Windows):**
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,8 +49,17 @@ yay -S fizzy-cli
 ```
 
 **Homebrew (macOS):**
+
+Latest stable Fizzy 3.x is available from the original tap:
+
 ```bash
-brew install basecamp/tap/fizzy
+brew install robzolkos/fizzy-cli/fizzy-cli
+```
+
+Fizzy 4 release candidates are available from [Releases](https://github.com/basecamp/fizzy-cli/releases). Fizzy 4 stable will be published from Basecamp's Homebrew tap:
+
+```bash
+brew install --cask basecamp/tap/fizzy
 ```
 
 **Scoop (Windows):**


### PR DESCRIPTION
## Summary

- clarifies that Fizzy 3.x remains available from the original Homebrew tap
- notes that Fizzy 4 RCs are published through GitHub Releases
- documents the planned Fizzy 4 stable cask command for Basecamp's tap

## Testing

- Not run; docs-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Homebrew install paths for the Fizzy 4 transition. Adds a clear note that the Basecamp tap is only for 4.x stable; RCs are not published to Homebrew.

- **Migration**
  - Install 3.x stable: brew install `robzolkos/fizzy-cli/fizzy-cli`
  - Get 4.x RCs: download from GitHub Releases (not available via Homebrew)
  - When 4.x stable ships: brew install --cask `basecamp/tap/fizzy`

<sup>Written for commit d55e8a6f0dc2940c92f012e8c66c49d6a6caa55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

