### PR TITLE
Sync Dependabot action pin comments via reusable workflow

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -10,6 +10,7 @@ on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
     workflows: [CI]
     types: [completed]
+    branches: ["dependabot/github_actions/**"]
   workflow_dispatch:
     inputs:
       branch:
@@ -26,8 +27,9 @@ permissions: {}
 
 jobs:
   sync:
-    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
-    # the reusable workflow re-checks this and everything else.
+    # Defense-in-depth behind the trigger-level branches filter (which stops
+    # runs from being created for other branches at all); the reusable
+    # workflow re-checks this and everything else.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -1,0 +1,47 @@
+name: Sync Dependabot action pin comments
+
+# Thin caller: all logic lives in basecamp/.github's reusable workflow —
+# trusted default-branch code that fetches the Dependabot head branch as data
+# only, rewrites stale `# vX.Y.Z` pin comments, and pushes back behind a
+# compare-and-swap lease using the write deploy key scoped to this repo's
+# dependabot-sync environment.
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
+    workflows: [CI]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Dependabot branch to sync (dependabot/github_actions/...)
+        required: true
+        type: string
+      e2e:
+        description: "E2E proof mode: expect a draft PR authored by the dispatcher on a dependabot/github_actions/e2e-proof-* branch"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  sync:
+    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
+    # the reusable workflow re-checks this and everything else.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    with:
+      ci-workflow-name: CI
+      default-branch: master
+      branch: ${{ inputs.branch || '' }}
+      e2e: ${{ inputs.e2e || false }}
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    # The deploy key is scoped to this repo's dependabot-sync environment
+    # (deployment branches: default branch only); environment secrets cannot
+    # be forwarded explicitly to a reusable workflow, so inherit is required.
+    secrets: inherit # zizmor: ignore[secrets-inherit] -- see above; the called workflow is SHA-pinned and reads only SYNC_ACTIONS_DEPLOY_KEY, gated by the dependabot-sync environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.4.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 name: Security
 
 on:
+  workflow_dispatch:
   workflow_call:
   push:
     branches: [master]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
Thin caller for the `dependabot-sync-actions-comments` reusable workflow (basecamp/.github#8, merged as 95a9f7a2). After CI completes on a Dependabot `github_actions` branch, trusted default-branch code fixes any stale `# vX.Y.Z` pin comments — including compound ones with trailing `# zizmor: ignore[...]` annotations that Dependabot can't rewrite — and pushes back behind a compare-and-swap lease.

Security model (openclaw-basecamp lineage, hardened after basecamp-sdk#458 review): the Dependabot head branch is fetched as *data* and never executed; the push uses a write deploy key scoped to this repo's `dependabot-sync` environment, whose deployment branch policy allows only the default branch (App tokens can't push workflow-file changes at all). Environment + deploy key are already provisioned.

Also adds `workflow_dispatch` to test.yml and security.yml so the reusable workflow's CI-dispatch fallback can re-run checks on the pushed head (the other repos already had it).

Second commit is a one-time catch-up running the updater against current workflows: 1 stale comment in release.yml (setup-go v6.4.0→v7.0.0).

Runtime validation: after merge, a `workflow_dispatch` run against a live Dependabot actions branch (basecamp-cli#566 is the standing candidate) proves the full fix→guard→push→re-CI loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates syncing of GitHub Actions pin version comments on Dependabot `github_actions` branches using the SHA-pinned reusable workflow from `basecamp/.github`. Adds a trigger-level branch filter for safety, and updates one stale comment in `release.yml` for `actions/setup-go` to `v7.0.0`.

- **New Features**
  - Added `.github/workflows/dependabot-sync-actions-comments.yml` to rewrite stale `# vX.Y.Z` pin comments (including with `# zizmor: ignore[...]`), fetch the Dependabot head as data, and push via the `dependabot-sync` deploy key; includes a trigger-level `workflow_run` filter for `dependabot/github_actions/**` with a job-level guard for defense-in-depth.
  - Enabled `workflow_dispatch` on `CI` and `Security` workflows so checks can re-run on the pushed head.

<sup>Written for commit 447780fd3d6068deef03893d22ab04c1d95817b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

