### PR TITLE
Re-pin dependabot-sync reusable workflow past the dispatch fallback

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -33,7 +33,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@9ca40e3b2d6be769b370b7cee86e8448267c95d8
     with:
       ci-workflow-name: CI
       default-branch: master


### PR DESCRIPTION
basecamp/.github#10 removed the CI-dispatch fallback (valid Codex P1 on fizzy-cli#189: `gh workflow run <wf> --ref <dependabot-branch>` executes the branch's freshly-bumped, unreviewed action pins outside the Dependabot-restricted `pull_request` context). The reusable workflow now verifies CI started on the pushed head — which deploy-key pushes trigger normally — and warns a maintainer if not, never dispatching branch workflows. Pin bump only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pinned the `basecamp/.github` dependabot-sync reusable workflow past the dispatch fallback removal. It now verifies CI started on the pushed head and warns instead of dispatching branch workflows, preventing unreviewed action pins from running outside Dependabot’s sandbox.

<sup>Written for commit b7521bf2eae5aa01974d8c1f4628cc418c25fc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

