### PR TITLE
Point Homebrew instructions at the v4 cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,25 @@ Use `fizzy doctor` any time you want a full health check of your install, config
 yay -S fizzy-cli
 ```
 
-**Homebrew (macOS):**
-
-Latest stable Fizzy 3.x is available from the original tap:
+**Homebrew (macOS and Linux):**
 
 ```bash
-brew install robzolkos/fizzy-cli/fizzy-cli
+brew install --cask basecamp/tap/fizzy
 ```
 
-Fizzy 4 release candidates are available from [Releases](https://github.com/basecamp/fizzy-cli/releases).
+Release candidates are not published to Homebrew. They are available from [Releases](https://github.com/basecamp/fizzy-cli/releases).
 
-> [!WARNING]
-> The Basecamp Homebrew tap command is for Fizzy 4 stable once it is released. Release candidates are not published to Homebrew.
->
-> ```bash
-> brew install --cask basecamp/tap/fizzy
-> ```
+*Upgrading from Fizzy 3.x:* 3.x was distributed as the `fizzy-cli` formula from the `robzolkos/fizzy-cli` tap. That tap now points at this cask, so `brew update` will offer to move you across. If Homebrew reports that it cannot tap `basecamp/tap` automatically, finish the move yourself:
+
+```bash
+brew tap basecamp/tap
+brew trust basecamp/tap/fizzy
+brew install --cask basecamp/tap/fizzy
+brew uninstall --formula --force fizzy-cli
+brew untap robzolkos/fizzy-cli
+```
+
+Homebrew will not tap a third-party tap on your behalf without explicit trust, which is why `brew trust` is needed.
 
 **Scoop (Windows):**
 ```bash

--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ Release candidates are not published to Homebrew. They are available from [Relea
 
 ```bash
 brew tap basecamp/tap
-brew trust basecamp/tap/fizzy
 brew install --cask basecamp/tap/fizzy
 brew uninstall --formula --force fizzy-cli
 brew untap robzolkos/fizzy-cli
 ```
 
-Homebrew will not tap a third-party tap on your behalf without explicit trust, which is why `brew trust` is needed.
+Installing by fully-qualified name trusts the cask automatically, so no separate `brew trust` step is needed.
 
 **Scoop (Windows):**
 ```bash


### PR DESCRIPTION
v4.0.0 published `Casks/fizzy.rb` and `fizzy.json` to `basecamp/homebrew-tap`, so the README's Homebrew section is now out of date in a way that will break.

## The problem

`README.md` currently tells new users:

```bash
brew install robzolkos/fizzy-cli/fizzy-cli
```

That command **breaks** as soon as [robzolkos/homebrew-fizzy-cli#2](https://github.com/robzolkos/homebrew-fizzy-cli/pull/2) lands, which removes `Formula/fizzy-cli.rb` in favour of `tap_migrations.json`. Two more stale bits:

- "Fizzy 4 release candidates are available from Releases" — 4.0.0 is stable now
- The cask command was buried in a `[!WARNING]` saying it's "for Fizzy 4 stable once it is released" — it is released, so the warning now reads as *don't use this*

## Changes

- `brew install --cask basecamp/tap/fizzy` becomes the primary Homebrew instruction
- Retitled to **Homebrew (macOS and Linux)** — the generated cask ships `on_linux` blocks for amd64/arm64
- Kept the "RCs are not published to Homebrew" note, unwrapped from the stale warning
- Added the manual upgrade path for 3.x users

Scoop section left as-is — it was previously broken (no manifest in the tap), and v4.0.0 published `fizzy.json`, so it is now correct.

## Why the manual upgrade path is documented

The tap migration is not silent for most users. Homebrew's `migrate_tap_migration` only auto-migrates when `basecamp/tap` is *already tapped locally*. Otherwise it hits the untrusted-tap gate and prints commands rather than running them, because Homebrew will not tap a third-party tap without explicit `brew trust`. Users who already have `basecamp/tap` (basecamp-cli users) get the automatic `unlink` → `cleanup` → `install --cask` path.

## Merge order

Merge this **before** robzolkos/homebrew-fizzy-cli#2. This PR is safe now — it documents a cask that already exists and is verified installable. Merging the tap PR first leaves a window where the README hands people a deleted formula.

One sentence here ("that tap now points at this cask") is slightly ahead of reality until #2 lands. It degrades gracefully: the manual commands below it work today regardless.

## Verification

- `Casks/fizzy.rb` present in `basecamp/homebrew-tap`, token `fizzy`, version `4.0.0`
- sha256 for `fizzy_4.0.0_darwin_arm64.tar.gz` matches the release asset exactly
- Archive layout matches the cask stanzas: `fizzy` at root, `completions/fizzy.{bash,zsh,fish}`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to install Fizzy 4 via the `basecamp/tap` cask: `brew install --cask basecamp/tap/fizzy`. Removes stale 3.x formula guidance, notes macOS and Linux support, and clarifies RCs are only on Releases.

- **Migration**
  - 3.x used the `fizzy-cli` formula from `robzolkos/fizzy-cli`; the tap now points to the cask and `brew update` may offer migration. If auto-migration is blocked, run: `brew tap basecamp/tap`, `brew install --cask basecamp/tap/fizzy`, `brew uninstall --formula --force fizzy-cli`, `brew untap robzolkos/fizzy-cli`. Installing by fully-qualified name auto-trusts the cask; no `brew trust` needed.

<sup>Written for commit 8ad8c3497929ca04ad59bf71d55a65e7b3736b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

