### PR TITLE
Bare pin comments: let Dependabot maintain action version comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
Dependabot rewrites *bare* `# vX.Y.Z` comments on pinned `uses:` lines natively but cannot touch compound ones carrying a trailing `# zizmor: ignore[...]`. Moving each ignore to its own line directly below the pin (reason text kept, association verified under zizmor 1.28) makes Dependabot itself the comment maintainer — no push automation required on its PRs. Same restructure basecamp-sdk shipped in basecamp-sdk#458. Part of the post-merge redesign of the comment-sync program (see basecamp/.github#10 for why in-PR pushing is unsafe: a deploy-key push flips the run actor off dependabot[bot] and lifts the Dependabot sandbox for the unreviewed bumped actions).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `zizmor` ignores to their own lines under pinned `uses:` steps so Dependabot can maintain the bare `# vX.Y.Z` comments without push automation. In `.github/workflows/release.yml`, split the trailing ignore from the `actions/setup-go` pin (`# v7.0.0`) into a standalone line directly below it.

<sup>Written for commit 74a49fafdb98c9db24fc5cd08859c0dcc674d3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

