### PR TITLE
Fix v4.0.0 release fallout: install.sh assets, AUR key fail-fast, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,11 @@ yay -S fizzy-cli
 
 **Homebrew (macOS):**
 
-Latest stable Fizzy 3.x is available from the original tap:
-
 ```bash
-brew install robzolkos/fizzy-cli/fizzy-cli
+brew install --cask basecamp/tap/fizzy
 ```
 
-Fizzy 4 release candidates are available from [Releases](https://github.com/basecamp/fizzy-cli/releases).
-
-> [!WARNING]
-> The Basecamp Homebrew tap command is for Fizzy 4 stable once it is released. Release candidates are not published to Homebrew.
->
-> ```bash
-> brew install --cask basecamp/tap/fizzy
-> ```
+Release candidates are not published to Homebrew; they are available from [Releases](https://github.com/basecamp/fizzy-cli/releases).
 
 **Scoop (Windows):**
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,23 +51,20 @@ Technical testers can install prereleases explicitly from the GitHub release ass
 
 ## CI Secrets
 
-### Repository level (`Settings > Secrets and variables > Actions`)
+All release credentials live in the `release` environment (`Settings > Environments > release`), so they are only exposed to jobs that pass the environment's required-reviewer gate. There are no repository-level release secrets. `HOMEBREW_TAP_TOKEN` does not exist as a stored secret — it is minted per-run from the `cli-release-bot` GitHub App credentials.
 
 | Name | Type | Purpose |
 |------|------|---------|
 | `RELEASE_CLIENT_ID` | variable | GitHub App client ID for `cli-release-bot` |
 | `RELEASE_APP_PRIVATE_KEY` | secret | GitHub App private key for tap push |
 | `AUR_KEY` | secret | ed25519 SSH private key for AUR (optional) |
+| `MACOS_SIGN_P12` | secret | Base64-encoded Developer ID Application .p12 |
+| `MACOS_SIGN_PASSWORD` | secret | Password for the .p12 certificate |
+| `MACOS_NOTARY_KEY` | secret | Base64-encoded App Store Connect API key (.p8) |
+| `MACOS_NOTARY_KEY_ID` | secret | App Store Connect API key ID (10 chars) |
+| `MACOS_NOTARY_ISSUER_ID` | secret | App Store Connect issuer UUID |
 
-### Environment level (`release` environment — `Settings > Environments`)
-
-| Secret | Purpose |
-|--------|---------|
-| `MACOS_SIGN_P12` | Base64-encoded Developer ID Application .p12 |
-| `MACOS_SIGN_PASSWORD` | Password for the .p12 certificate |
-| `MACOS_NOTARY_KEY` | Base64-encoded App Store Connect API key (.p8) |
-| `MACOS_NOTARY_KEY_ID` | App Store Connect API key ID (10 chars) |
-| `MACOS_NOTARY_ISSUER_ID` | App Store Connect issuer UUID |
+Set a secret with `gh secret set <NAME> --env release -R basecamp/fizzy-cli`. For multi-line secrets like SSH keys, pipe the file directly (`gh secret set AUR_KEY --env release < keyfile`) so newlines are preserved — pasting a flattened key produces an "invalid format" SSH failure at publish time.
 
 ## Distribution Channels
 
@@ -99,5 +96,18 @@ goreleaser release --snapshot --clean
 ## AUR Setup
 
 1. Generate ed25519 SSH keypair: `ssh-keygen -t ed25519 -f aur_key`
-2. Add public key to your AUR account profile
-3. Add private key as `AUR_KEY` secret on the fizzy-cli repo
+2. Add public key to the AUR account that maintains `fizzy-cli`
+3. Validate the private key parses and authenticates:
+   `ssh-keygen -y -f aur_key > /dev/null && ssh -T -i aur_key aur@aur.archlinux.org`
+   (expect "Interactive shell is disabled")
+4. Store it in the `release` environment, preserving newlines:
+   `gh secret set AUR_KEY --env release -R basecamp/fizzy-cli < aur_key`
+
+## Tap Migration Ordering
+
+When moving the Homebrew install path from another tap to `basecamp/tap` (learned during the v4.0.0 release, 2026-07-27):
+
+1. **First** ship a stable release so GoReleaser publishes `Casks/fizzy.rb` to `basecamp/homebrew-tap`. The cask must exist before anything points at it.
+2. **Then** land `tap_migrations.json` (mapping the old formula to `basecamp/tap/fizzy`) in the old tap and remove its formula. `brew update` surfaces the migration to existing users.
+3. Do **not** transfer the old tap repo into the basecamp org — a repo named `homebrew-*` or matching `basecamp/fizzy-cli` would become a stray implicit tap. Archive it once users have migrated.
+4. Update README install instructions last, once `brew install --cask basecamp/tap/fizzy` actually works.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,7 +64,7 @@ All release credentials live in the `release` environment (`Settings > Environme
 | `MACOS_NOTARY_KEY_ID` | secret | App Store Connect API key ID (10 chars) |
 | `MACOS_NOTARY_ISSUER_ID` | secret | App Store Connect issuer UUID |
 
-Set a secret with `gh secret set <NAME> --env release -R basecamp/fizzy-cli`; the `RELEASE_CLIENT_ID` variable uses `gh variable set` instead. For multi-line secrets like SSH keys, pipe the file directly (`gh secret set AUR_KEY --env release < keyfile`) so newlines are preserved — pasting a flattened key produces an "invalid format" SSH failure at publish time.
+Set a secret with `gh secret set <NAME> --env release -R basecamp/fizzy-cli`; the `RELEASE_CLIENT_ID` variable uses `gh variable set` instead. For multi-line secrets like SSH keys, pipe the file directly (`gh secret set AUR_KEY --env release -R basecamp/fizzy-cli < keyfile`) so newlines are preserved — pasting a flattened key produces an "invalid format" SSH failure at publish time.
 
 ## Distribution Channels
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,7 +64,7 @@ All release credentials live in the `release` environment (`Settings > Environme
 | `MACOS_NOTARY_KEY_ID` | secret | App Store Connect API key ID (10 chars) |
 | `MACOS_NOTARY_ISSUER_ID` | secret | App Store Connect issuer UUID |
 
-Set a secret with `gh secret set <NAME> --env release -R basecamp/fizzy-cli`. For multi-line secrets like SSH keys, pipe the file directly (`gh secret set AUR_KEY --env release < keyfile`) so newlines are preserved — pasting a flattened key produces an "invalid format" SSH failure at publish time.
+Set a secret with `gh secret set <NAME> --env release -R basecamp/fizzy-cli`; the `RELEASE_CLIENT_ID` variable uses `gh variable set` instead. For multi-line secrets like SSH keys, pipe the file directly (`gh secret set AUR_KEY --env release < keyfile`) so newlines are preserved — pasting a flattened key produces an "invalid format" SSH failure at publish time.
 
 ## Distribution Channels
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,31 +34,32 @@ if [ -z "$VERSION" ]; then
 fi
 echo "Latest version: $VERSION"
 
-# Download binary
-BINARY_NAME="fizzy-${OS}-${ARCH}"
+# Download release archive
+EXT="tar.gz"
 if [ "$OS" = "windows" ]; then
-  BINARY_NAME="fizzy-${OS}-${ARCH}.exe"
+  EXT="zip"
 fi
+ARCHIVE="fizzy_${VERSION#v}_${OS}_${ARCH}.${EXT}"
 
-DOWNLOAD_URL="https://github.com/$REPO/releases/download/${VERSION}/${BINARY_NAME}"
-CHECKSUMS_URL="https://github.com/$REPO/releases/download/${VERSION}/SHA256SUMS-${OS}-${ARCH}.txt"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/${VERSION}/${ARCHIVE}"
+CHECKSUMS_URL="https://github.com/$REPO/releases/download/${VERSION}/checksums.txt"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-echo "Downloading $BINARY_NAME..."
-curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/$BINARY_NAME"
+echo "Downloading $ARCHIVE..."
+curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/$ARCHIVE"
 curl -fsSL "$CHECKSUMS_URL" -o "$TMPDIR/checksums.txt"
 
 # Verify SHA256
 echo "Verifying checksum..."
 cd "$TMPDIR"
-EXPECTED=$(awk '{print $1}' checksums.txt)
+EXPECTED=$(grep " ${ARCHIVE}\$" checksums.txt | awk '{print $1}')
 if [ -z "$EXPECTED" ]; then
-  echo "ERROR: Checksum not found"
+  echo "ERROR: Checksum for $ARCHIVE not found in checksums.txt"
   exit 1
 fi
-ACTUAL=$(sha256sum "$BINARY_NAME" 2>/dev/null || shasum -a 256 "$BINARY_NAME" | awk '{print $1}')
+ACTUAL=$(sha256sum "$ARCHIVE" 2>/dev/null || shasum -a 256 "$ARCHIVE" | awk '{print $1}')
 ACTUAL=$(echo "$ACTUAL" | awk '{print $1}')
 if [ "$EXPECTED" != "$ACTUAL" ]; then
   echo "ERROR: Checksum mismatch!"
@@ -68,13 +69,24 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "Checksum verified."
 
-# Install
-mkdir -p "$INSTALL_DIR"
+# Extract
 BINARY="fizzy"
 if [ "$OS" = "windows" ]; then
   BINARY="fizzy.exe"
 fi
-cp "$BINARY_NAME" "$INSTALL_DIR/${BINARY}"
+if [ "$EXT" = "zip" ]; then
+  if command -v unzip > /dev/null; then
+    unzip -q "$ARCHIVE" "$BINARY"
+  else
+    tar -xf "$ARCHIVE" "$BINARY"
+  fi
+else
+  tar -xzf "$ARCHIVE" "$BINARY"
+fi
+
+# Install
+mkdir -p "$INSTALL_DIR"
+cp "$BINARY" "$INSTALL_DIR/${BINARY}"
 chmod +x "$INSTALL_DIR/${BINARY}"
 
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,7 +54,7 @@ curl -fsSL "$CHECKSUMS_URL" -o "$TMPDIR/checksums.txt"
 # Verify SHA256
 echo "Verifying checksum..."
 cd "$TMPDIR"
-EXPECTED=$(grep " ${ARCHIVE}\$" checksums.txt | awk '{print $1}')
+EXPECTED=$(awk -v f="$ARCHIVE" '$2 == f || $2 == "*" f {print $1}' checksums.txt)
 if [ -z "$EXPECTED" ]; then
   echo "ERROR: Checksum for $ARCHIVE not found in checksums.txt"
   exit 1
@@ -77,8 +77,11 @@ fi
 if [ "$EXT" = "zip" ]; then
   if command -v unzip > /dev/null; then
     unzip -q "$ARCHIVE" "$BINARY"
+  elif tar -xf "$ARCHIVE" "$BINARY" 2>/dev/null && [ -f "$BINARY" ]; then
+    :  # bsdtar (Windows 10+ tar.exe) reads zip archives
   else
-    tar -xf "$ARCHIVE" "$BINARY"
+    echo "ERROR: Could not extract $ARCHIVE — install unzip and re-run"
+    exit 1
   fi
 else
   tar -xzf "$ARCHIVE" "$BINARY"

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -88,8 +88,8 @@ EOF
 mkdir -p ~/.ssh
 printf '%s\n' "$AUR_KEY" | tr -d '\r' > ~/.ssh/aur
 chmod 600 ~/.ssh/aur
-if ! ssh-keygen -y -f ~/.ssh/aur > /dev/null; then
-  echo "ERROR: AUR_KEY is not a valid SSH private key." \
+if ! ssh-keygen -y -f ~/.ssh/aur < /dev/null > /dev/null; then
+  echo "ERROR: AUR_KEY is not a valid unencrypted SSH private key." \
        "Re-store it with newlines intact: gh secret set AUR_KEY --env release < keyfile"
   exit 1
 fi

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -86,8 +86,13 @@ EOF
 
 # Clone AUR repo and push
 mkdir -p ~/.ssh
-echo "$AUR_KEY" > ~/.ssh/aur
+printf '%s\n' "$AUR_KEY" | tr -d '\r' > ~/.ssh/aur
 chmod 600 ~/.ssh/aur
+if ! ssh-keygen -y -f ~/.ssh/aur > /dev/null; then
+  echo "ERROR: AUR_KEY is not a valid SSH private key." \
+       "Re-store it with newlines intact: gh secret set AUR_KEY --env release < keyfile"
+  exit 1
+fi
 cat >> ~/.ssh/config << SSHEOF
 Host aur.archlinux.org
     IdentityFile ~/.ssh/aur

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -8,6 +8,11 @@ if [ -z "${GITHUB_REF_NAME:-}" ]; then
   echo "ERROR: GITHUB_REF_NAME is not set (must run from GitHub Actions release workflow)"
   exit 1
 fi
+if [ -z "${AUR_KEY:-}" ]; then
+  echo "ERROR: AUR_KEY is not set." \
+       "Store it with: gh secret set AUR_KEY --env release < keyfile"
+  exit 1
+fi
 VERSION="${GITHUB_REF_NAME#v}"
 REPO="basecamp/fizzy-cli"
 

--- a/scripts/publish-aur.sh
+++ b/scripts/publish-aur.sh
@@ -10,7 +10,7 @@ if [ -z "${GITHUB_REF_NAME:-}" ]; then
 fi
 if [ -z "${AUR_KEY:-}" ]; then
   echo "ERROR: AUR_KEY is not set." \
-       "Store it with: gh secret set AUR_KEY --env release < keyfile"
+       "Store it with: gh secret set AUR_KEY --env release -R basecamp/fizzy-cli < keyfile"
   exit 1
 fi
 VERSION="${GITHUB_REF_NAME#v}"
@@ -95,7 +95,7 @@ printf '%s\n' "$AUR_KEY" | tr -d '\r' > ~/.ssh/aur
 chmod 600 ~/.ssh/aur
 if ! ssh-keygen -y -f ~/.ssh/aur < /dev/null > /dev/null; then
   echo "ERROR: AUR_KEY is not a valid unencrypted SSH private key." \
-       "Re-store it with newlines intact: gh secret set AUR_KEY --env release < keyfile"
+       "Re-store it with newlines intact: gh secret set AUR_KEY --env release -R basecamp/fizzy-cli < keyfile"
   exit 1
 fi
 cat >> ~/.ssh/config << SSHEOF


### PR DESCRIPTION
Follow-ups from the v4.0.0 stable release (run 30305193571).

## What broke

- **`scripts/install.sh` is broken in production.** v4.0.0 became `latest`, and the installer still fetches the v3 asset scheme (`fizzy-<os>-<arch>` bare binaries + `SHA256SUMS-<os>-<arch>.txt`), which GoReleaser no longer publishes. Every `curl | bash` install currently 404s.
- **The `aur-publish` job failed** with `Load key "/home/runner/.ssh/aur": invalid format` — the stored `AUR_KEY` secret content is not a parseable OpenSSH key (likely flattened newlines). This was the first run to ever exercise it.

## Changes

- **install.sh**: rewritten for the GoReleaser layout — downloads `fizzy_<ver>_<os>_<arch>.tar.gz` (`.zip` on Windows), verifies against the single `checksums.txt`, extracts the binary. Fixed as soon as this merges, since the installer is served from the repo.
- **publish-aur.sh**: writes the key with `printf | tr -d '\r'` and validates it with `ssh-keygen -y` immediately, failing with a clear remediation message (`gh secret set AUR_KEY --env release < keyfile`) instead of dying mid-clone.
- **README**: Homebrew install is now `brew install --cask basecamp/tap/fizzy` (cask is live in `basecamp/homebrew-tap`); dropped the robzolkos tap instructions and the stale "not yet released" warning.
- **RELEASING.md**: corrected the secret inventory (`RELEASE_CLIENT_ID`/`RELEASE_APP_PRIVATE_KEY`/`AUR_KEY` live in the `release` environment, not repository level; `HOMEBREW_TAP_TOKEN` is minted per-run by the `cli-release-bot` App), documented the multi-line secret pitfall, fixed the AUR setup steps to include local key validation, and added a tap-migration ordering runbook.

## Verification

- install.sh run live against v4.0.0 on darwin-arm64 (this Mac), linux-amd64 (Debian container), and native Arch x86_64 — all install and report `fizzy version 4.0.0`.
- The generated PKGBUILD/.SRCINFO were build-tested in an Arch container: `makepkg` builds 4.0.0 from the source tarball, `.SRCINFO` matches `makepkg --printsrcinfo`, the installed package runs and ships completions + license. (The PKGBUILD had never been exercised — the AUR job always died at SSH.)
- The fail-fast path was tested with a garbage `AUR_KEY`: PKGBUILD generation completes, then the script exits with the clear error.

## Not in this PR (pending @robzolkos)

- Re-store `AUR_KEY` from a validated key file and `gh run rerun 30305193571 --failed`.
- Merge the tap migration on `robzolkos/homebrew-fizzy-cli`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v4.0.0 installs by switching the installer to GoReleaser archives with exact filename checksum matching and safer extraction. Hardens AUR publishing with fail-fast, non-interactive key checks; updates Homebrew docs and release secret setup.

- **Bug Fixes**
  - Rewrites `scripts/install.sh` to download `fizzy_<ver>_<os>_<arch>.tar.gz` (Windows `.zip`), verify against `checksums.txt` by exact archive name (tolerates leading `*`), extract with `unzip` or zip-capable `tar`, and error clearly if neither is available.
  - Updates `scripts/publish-aur.sh` to preserve newlines and strip CRs when writing `AUR_KEY`, validate non-interactively with `ssh-keygen -y` (stdin from `/dev/null`) to fail fast on invalid or passphrase-protected keys, and guard missing `AUR_KEY` with a copy-pasteable remediation (`gh secret set AUR_KEY --env release -R basecamp/fizzy-cli < keyfile`).

- **Docs**
  - README: Homebrew install is now `brew install --cask basecamp/tap/fizzy`; prereleases are available from Releases.
  - RELEASING.md: all release credentials live in the `release` environment; adds exact `gh` commands with `-R basecamp/fizzy-cli` (multi-line secret example included), notes `RELEASE_CLIENT_ID` uses `gh variable set`, documents multi-line secret pitfalls and AUR key validation, and adds tap migration ordering.

<sup>Written for commit 6d7268cd7c1de2e424e384b5ff427c4849f93a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

