### PR TITLE
Correct the --board scope and document the surface gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ E2E environment variables:
 ## Configuration
 
 The CLI reads config from multiple sources with this priority:
-1. CLI flags (`--token`, `--profile`, `--api-url`, `--board`)
+1. CLI flags (`--token`, `--profile`, `--api-url`)
 2. Environment variables (`FIZZY_TOKEN`, `FIZZY_PROFILE`, `FIZZY_API_URL`, `FIZZY_BOARD`)
 3. Named profile settings (base URL, board from `~/.config/fizzy/config.json`)
 4. Local project config (`.fizzy.yaml`)
@@ -88,6 +88,21 @@ The CLI reads config from multiple sources with this priority:
 
 `FIZZY_ACCOUNT` is accepted as a deprecated alias for `FIZZY_PROFILE`.
 
+**`--board` is not a global flag.** `fizzy --board X ...` fails with `unknown flag`.
+The webhook subcommands declare their own `--board`; everywhere else the board comes
+from `FIZZY_BOARD` or the `board` key in config, resolved by `requireBoard`.
+
 ## Authentication
 
 Token-based via personal access tokens. Run `fizzy setup` for interactive configuration or `fizzy auth login` to save a token directly.
+
+## Checks
+
+`make check` runs `fmt-check vet lint tidy-check race-test`. It does **not** include the
+CLI surface gate.
+
+`SURFACE.txt` at the repository root is a golden snapshot of every command, flag and
+help string. `TestSurfaceSnapshot` compares against it, and CI's `go test ./...` runs
+that test, so any change to the CLI surface fails the build until the snapshot is
+refreshed. Regenerate with `make surface-snapshot` (or check it alone with
+`make surface-check`) and commit the result in the same PR as the surface change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,10 @@ The CLI reads config from multiple sources with this priority:
 `FIZZY_ACCOUNT` is accepted as a deprecated alias for `FIZZY_PROFILE`.
 
 **`--board` is not a global flag.** `fizzy --board X ...` fails with `unknown flag`.
-The webhook subcommands declare their own `--board`; everywhere else the board comes
-from `FIZZY_BOARD` or the `board` key in config, resolved by `requireBoard`.
+It is declared per-command, by around nineteen of them across the activity, board,
+card, column and webhook groups — so `fizzy card list --board X` works while
+`fizzy --board X card list` does not. Commands that take a board but were not given
+one fall back to `FIZZY_BOARD` or the `board` key in config, via `requireBoard`.
 
 ## Authentication
 
@@ -98,11 +100,13 @@ Token-based via personal access tokens. Run `fizzy setup` for interactive config
 
 ## Checks
 
-`make check` runs `fmt-check vet lint tidy-check race-test`. It does **not** include the
-CLI surface gate.
+`make check` runs `fmt-check vet lint tidy-check race-test`. There is no `surface-check`
+in that list, but the surface gate still runs: `race-test` is
+`go test -race -count=1 ./internal/...`, which includes
+`internal/commands.TestSurfaceSnapshot`.
 
 `SURFACE.txt` at the repository root is a golden snapshot of every command, flag and
-help string. `TestSurfaceSnapshot` compares against it, and CI's `go test ./...` runs
-that test, so any change to the CLI surface fails the build until the snapshot is
-refreshed. Regenerate with `make surface-snapshot` (or check it alone with
-`make surface-check`) and commit the result in the same PR as the surface change.
+help string, and that test compares against it. So a change to the CLI surface fails
+both `make check` and CI until the snapshot is refreshed. Regenerate with
+`make surface-snapshot` (or run the gate alone with `make surface-check`) and commit
+the result in the same PR as the surface change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,8 @@ E2E environment variables:
 ## Configuration
 
 The CLI reads config from multiple sources with this priority:
-1. CLI flags (`--token`, `--profile`, `--api-url`)
+1. CLI flags (`--token`, `--profile`, `--api-url`, and `--board` on the commands that
+   accept it — see below; a given `--board` beats every configured default)
 2. Environment variables (`FIZZY_TOKEN`, `FIZZY_PROFILE`, `FIZZY_API_URL`, `FIZZY_BOARD`)
 3. Named profile settings (base URL, board from `~/.config/fizzy/config.json`)
 4. Local project config (`.fizzy.yaml`)
@@ -88,10 +89,12 @@ The CLI reads config from multiple sources with this priority:
 
 `FIZZY_ACCOUNT` is accepted as a deprecated alias for `FIZZY_PROFILE`.
 
-**`--board` is not a global flag.** `fizzy --board X ...` fails with `unknown flag`.
-It is declared per-command, by around nineteen of them across the activity, board,
-card, column and webhook groups — so `fizzy card list --board X` works while
-`fizzy --board X card list` does not. What happens when you omit it varies by command:
+**`--board` is command-scoped, not global.** `fizzy --board X ...` fails with
+`unknown flag`; it is declared per-command, by nineteen of them across the activity,
+board, card, column and webhook groups. So `fizzy card list --board X` works while
+`fizzy --board X card list` does not. Where it is accepted it sits at the top of the
+ladder above: `defaultBoard` returns the flag value before consulting `FIZZY_BOARD` or
+config. What happens when you omit it varies by command:
 
 - **Required** — `requireBoard` falls back to `FIZZY_BOARD` or the `board` key in
   config, and errors if neither is set. Seventeen commands: `board accesses`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,14 @@ The CLI reads config from multiple sources with this priority:
 **`--board` is not a global flag.** `fizzy --board X ...` fails with `unknown flag`.
 It is declared per-command, by around nineteen of them across the activity, board,
 card, column and webhook groups — so `fizzy card list --board X` works while
-`fizzy --board X card list` does not. Commands that take a board but were not given
-one fall back to `FIZZY_BOARD` or the `board` key in config, via `requireBoard`.
+`fizzy --board X card list` does not. What happens when you omit it varies by command:
+
+- **Required** (`card create`, `column create`, the webhook commands): `requireBoard`
+  falls back to `FIZZY_BOARD` or the `board` key in config, and errors if neither is set.
+- **Defaulted** (`card list`): `defaultBoard` applies the same fallback but does not
+  error — an empty board just goes unset.
+- **Optional filter** (`activity list`): no fallback at all. The board query parameter is
+  added only when the flag is given, so `FIZZY_BOARD` has no effect there.
 
 ## Authentication
 
@@ -105,8 +111,10 @@ in that list, but the surface gate still runs: `race-test` is
 `go test -race -count=1 ./internal/...`, which includes
 `internal/commands.TestSurfaceSnapshot`.
 
-`SURFACE.txt` at the repository root is a golden snapshot of every command, flag and
-help string, and that test compares against it. So a change to the CLI surface fails
+`SURFACE.txt` at the repository root is a golden snapshot of the CLI's *structure* --
+`CMD`, `SUB`, `FLAG` and `ARG` records -- and that test compares against it. It does not
+capture `Short`/`Long` help text or flag descriptions, so rewording help leaves the
+snapshot green. So a change to the CLI surface fails
 both `make check` and CI until the snapshot is refreshed. Regenerate with
 `make surface-snapshot` (or run the gate alone with `make surface-check`) and commit
 the result in the same PR as the surface change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,15 @@ It is declared per-command, by around nineteen of them across the activity, boar
 card, column and webhook groups — so `fizzy card list --board X` works while
 `fizzy --board X card list` does not. What happens when you omit it varies by command:
 
-- **Required** (`card create`, `column create`, the webhook commands): `requireBoard`
-  falls back to `FIZZY_BOARD` or the `board` key in config, and errors if neither is set.
-- **Defaulted** (`card list`): `defaultBoard` applies the same fallback but does not
-  error — an empty board just goes unset.
-- **Optional filter** (`activity list`): no fallback at all. The board query parameter is
-  added only when the flag is given, so `FIZZY_BOARD` has no effect there.
+- **Required** — `requireBoard` falls back to `FIZZY_BOARD` or the `board` key in
+  config, and errors if neither is set. Seventeen commands: `board accesses`,
+  `board closed`, `board postponed`, `board stream`, `card create`, `column list`,
+  `column show`, `column create`, `column update`, `column delete`, and all seven
+  `webhook` subcommands.
+- **Defaulted** — `card list` uses `defaultBoard`, the same fallback without the error;
+  an empty board just goes unset.
+- **Optional filter** — `activity list` has no fallback at all. The board query
+  parameter is added only when the flag is given, so `FIZZY_BOARD` has no effect there.
 
 ## Authentication
 


### PR DESCRIPTION
--board was listed in the global config-precedence ladder alongside --token,
--profile and --api-url. Those three are registered on rootCmd as persistent
flags; --board is not registered globally at all. Running `fizzy --board X`
exits with "unknown flag: --board", which is how this was confirmed rather
than by reading the registration. The webhook subcommands declare their own
--board, and elsewhere the board is resolved from FIZZY_BOARD or config.

FIZZY_BOARD stays in the ladder -- that one is real, handled in
internal/config/config.go. The same wrong claim appears in that file's Load()
doc comment; correcting source comments is left out of a documentation change.

Two gates were undocumented. `make check` is the local gate and notably does
not cover the CLI surface. SURFACE.txt is a 145 KB golden snapshot of every
command, flag and help string; TestSurfaceSnapshot compares against it and CI
runs it through `go test ./...`, so any surface change fails the build until
`make surface-snapshot` is rerun and the result committed. Someone adding a
flag would otherwise meet this as a mysterious CI failure.


---
Checked against `master` at 3ac1de713cd3e9f25ed8d2c71e06e3075bb74d96.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes config docs: `--board` is per-command (not global) across activity/board/card/column/webhook, and on those commands it ranks above `FIZZY_BOARD` and config in precedence. Clarifies board resolution (lists all 17 `requireBoard` commands; notes `defaultBoard` on `card list`; `activity list` has no fallback) and documents the surface gate: `make check` runs the snapshot test; `SURFACE.txt` is structural only; refresh with `make surface-snapshot` or `make surface-check` when the CLI surface changes.

<sup>Written for commit 2129405123647c1d1a4f9c8a2a7d7095f10c1a8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

